### PR TITLE
Implement 3D slider for insurance selection

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -11,12 +11,14 @@
     "orval:gen": "npx orval && npm run format:orval"
   },
   "dependencies": {
+    "@react-spring/three": "^10.0.1",
     "@react-three/drei": "^10.3.0",
     "@react-three/fiber": "^9.0.0-alpha.8",
     "@reown/appkit": "^1.7.6",
     "@reown/appkit-adapter-wagmi": "^1.7.6",
     "@swc/helpers": "^0.5.17",
     "@tanstack/react-query": "^5.77.1",
+    "@use-gesture/react": "^10.3.1",
     "ethers": "^6.14.1",
     "leva": "^0.10.0",
     "next": "15.3.2",

--- a/dashboard/src/app/insurance/page.tsx
+++ b/dashboard/src/app/insurance/page.tsx
@@ -2,18 +2,16 @@
 
 import React from 'react'
 import { Canvas } from '@react-three/fiber'
-import { OrbitControls } from '@react-three/drei'
 import { InsuranceSlider } from '@/components/InsuranceSlider'
 
 export default function InsurancePage() {
   return (
     <div className="w-full h-screen">
-      <Canvas camera={{ position: [2, 2, 4], fov: 50 }}>
+      <Canvas camera={{ position: [0, 0, 5], fov: 50 }}>
         <ambientLight intensity={0.5} />
         <directionalLight position={[5, 5, 5]} />
-        <OrbitControls />
         <InsuranceSlider />
       </Canvas>
     </div>
-  )
+  );
 }

--- a/dashboard/src/app/insurance/page.tsx
+++ b/dashboard/src/app/insurance/page.tsx
@@ -3,35 +3,16 @@
 import React from 'react'
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
-import { Leva, useControls } from 'leva'
-import { useInsuranceStore, InsurancePlan } from '@/store/insurance'
-import { InsuranceModels } from '@/components/InsuranceModels'
+import { InsuranceSlider } from '@/components/InsuranceSlider'
 
 export default function InsurancePage() {
-  const setSelectedPlan = useInsuranceStore((state) => state.setSelectedPlan)
-
-  const { plan } = useControls('Insurance Selection', {
-    plan: {
-      options: {
-        Basic: 'basic',
-        Premium: 'premium',
-        Platinum: 'platinum',
-      },
-    },
-  })
-
-  React.useEffect(() => {
-    setSelectedPlan(plan as InsurancePlan)
-  }, [plan, setSelectedPlan])
-
   return (
     <div className="w-full h-screen">
-      <Leva collapsed />
       <Canvas camera={{ position: [2, 2, 4], fov: 50 }}>
         <ambientLight intensity={0.5} />
         <directionalLight position={[5, 5, 5]} />
         <OrbitControls />
-        <InsuranceModels />
+        <InsuranceSlider />
       </Canvas>
     </div>
   )

--- a/dashboard/src/components/InsuranceSlider.tsx
+++ b/dashboard/src/components/InsuranceSlider.tsx
@@ -1,0 +1,73 @@
+import React, { useRef, useState } from 'react'
+import * as THREE from "three"
+import { Html } from '@react-three/drei'
+import { useFrame } from '@react-three/fiber'
+import { useInsuranceStore, InsurancePlan } from '@/store/insurance'
+
+// distance between items
+const SLIDE_WIDTH = 2
+const plans: InsurancePlan[] = ['basic', 'premium', 'platinum']
+
+export function InsuranceSlider() {
+  const group = useRef<THREE.Group>(null!)
+  const setSelectedPlan = useInsuranceStore((state) => state.setSelectedPlan)
+  const [index, setIndex] = useState(0)
+
+  const prev = () => {
+    setIndex((i) => (i + plans.length - 1) % plans.length)
+  }
+
+  const next = () => {
+    setIndex((i) => (i + 1) % plans.length)
+  }
+
+  useFrame((state, delta) => {
+    if (group.current) {
+      const targetX = -index * SLIDE_WIDTH
+      group.current.position.x += (targetX - group.current.position.x) * 5 * delta
+    }
+  })
+
+  React.useEffect(() => {
+    setSelectedPlan(plans[index])
+  }, [index, setSelectedPlan])
+
+  return (
+    <>
+      <group ref={group}>
+        {/* Basic - Cube */}
+        <mesh position={[0, 0, 0]}>
+          <boxGeometry args={[1, 1, 1]} />
+          <meshStandardMaterial color="lightgreen" />
+        </mesh>
+        {/* Premium - Sphere */}
+        <mesh position={[SLIDE_WIDTH, 0, 0]}>
+          <sphereGeometry args={[0.75, 32, 32]} />
+          <meshStandardMaterial color="gold" />
+        </mesh>
+        {/* Platinum - Cone */}
+        <mesh position={[SLIDE_WIDTH * 2, 0, 0]}>
+          <coneGeometry args={[0.8, 1.2, 32]} />
+          <meshStandardMaterial color="silver" />
+        </mesh>
+      </group>
+      {/* Simple controls */}
+      <Html position={[0, -1.5, 0]} center>
+        <div className="flex space-x-4">
+          <button
+            onClick={prev}
+            className="px-2 py-1 bg-gray-200 rounded-md text-black"
+          >
+            Prev
+          </button>
+          <button
+            onClick={next}
+            className="px-2 py-1 bg-gray-200 rounded-md text-black"
+          >
+            Next
+          </button>
+        </div>
+      </Html>
+    </>
+  )
+}

--- a/dashboard/src/components/InsuranceSlider.tsx
+++ b/dashboard/src/components/InsuranceSlider.tsx
@@ -1,73 +1,71 @@
-import React, { useRef, useState } from 'react'
-import * as THREE from "three"
-import { Html } from '@react-three/drei'
-import { useFrame } from '@react-three/fiber'
-import { useInsuranceStore, InsurancePlan } from '@/store/insurance'
+"use client";
 
-// distance between items
-const SLIDE_WIDTH = 2
-const plans: InsurancePlan[] = ['basic', 'premium', 'platinum']
+import React, { useRef } from "react";
+import { animated, useSpring } from "@react-spring/three";
+import { useDrag } from "@use-gesture/react";
+import { Text } from "@react-three/drei";
+import { useInsuranceStore, InsurancePlan } from "@/store/insurance";
+
+const plans: InsurancePlan[] = [
+  "medical",
+  "flight",
+  "travel",
+  "life",
+  "accident",
+];
+const CARD_SPACING = 3;
+const SCROLL_DAMPING = 0.005; // ✅ Works well between 0.15 – 0.3
+
+const colors: Record<InsurancePlan, string> = {
+  medical: "#90ee90",
+  flight: "#add8e6",
+  travel: "#ffc0cb",
+  life: "#ffd580",
+  accident: "#e1bee7",
+};
 
 export function InsuranceSlider() {
-  const group = useRef<THREE.Group>(null!)
-  const setSelectedPlan = useInsuranceStore((state) => state.setSelectedPlan)
-  const [index, setIndex] = useState(0)
+  const setSelectedPlan = useInsuranceStore((s) => s.setSelectedPlan);
+  const dragOffset = useRef(0);
+  const totalWidth = (plans.length - 1) * CARD_SPACING;
 
-  const prev = () => {
-    setIndex((i) => (i + plans.length - 1) % plans.length)
-  }
+  const [{ x }, api] = useSpring(() => ({ x: 0 }));
 
-  const next = () => {
-    setIndex((i) => (i + 1) % plans.length)
-  }
+  const bind = useDrag(({ movement: [mx], last }) => {
+    const damped = mx * SCROLL_DAMPING;
+    const newX = dragOffset.current + damped;
+    const clampedX = Math.min(0, Math.max(-totalWidth, newX));
 
-  useFrame((state, delta) => {
-    if (group.current) {
-      const targetX = -index * SLIDE_WIDTH
-      group.current.position.x += (targetX - group.current.position.x) * 5 * delta
+    api.start({ x: clampedX, immediate: true });
+
+    if (last) {
+      dragOffset.current = clampedX;
+
+      // Optional: update visible plan
+      const index = Math.round(Math.abs(clampedX) / CARD_SPACING);
+      setSelectedPlan(plans[index]);
     }
-  })
-
-  React.useEffect(() => {
-    setSelectedPlan(plans[index])
-  }, [index, setSelectedPlan])
+  });
 
   return (
-    <>
-      <group ref={group}>
-        {/* Basic - Cube */}
-        <mesh position={[0, 0, 0]}>
-          <boxGeometry args={[1, 1, 1]} />
-          <meshStandardMaterial color="lightgreen" />
-        </mesh>
-        {/* Premium - Sphere */}
-        <mesh position={[SLIDE_WIDTH, 0, 0]}>
-          <sphereGeometry args={[0.75, 32, 32]} />
-          <meshStandardMaterial color="gold" />
-        </mesh>
-        {/* Platinum - Cone */}
-        <mesh position={[SLIDE_WIDTH * 2, 0, 0]}>
-          <coneGeometry args={[0.8, 1.2, 32]} />
-          <meshStandardMaterial color="silver" />
-        </mesh>
-      </group>
-      {/* Simple controls */}
-      <Html position={[0, -1.5, 0]} center>
-        <div className="flex space-x-4">
-          <button
-            onClick={prev}
-            className="px-2 py-1 bg-gray-200 rounded-md text-black"
+    <animated.group {...bind()} position-x={x}>
+      {plans.map((plan, i) => (
+        <group key={plan} position={[i * CARD_SPACING, 0, 0]}>
+          <mesh>
+            <planeGeometry args={[2, 2.5]} />
+            <meshStandardMaterial color={colors[plan]} />
+          </mesh>
+          <Text
+            position={[0, 0.6, 0.01]}
+            fontSize={0.4}
+            color="black"
+            anchorX="center"
+            anchorY="middle"
           >
-            Prev
-          </button>
-          <button
-            onClick={next}
-            className="px-2 py-1 bg-gray-200 rounded-md text-black"
-          >
-            Next
-          </button>
-        </div>
-      </Html>
-    </>
-  )
+            {plan.toUpperCase()}
+          </Text>
+        </group>
+      ))}
+    </animated.group>
+  );
 }

--- a/dashboard/src/store/insurance.ts
+++ b/dashboard/src/store/insurance.ts
@@ -1,13 +1,18 @@
-import create from 'zustand'
+import { create } from "zustand";
 
-export type InsurancePlan = 'basic' | 'premium' | 'platinum'
+export type InsurancePlan =
+  | "medical"
+  | "flight"
+  | "travel"
+  | "life"
+  | "accident";
 
 interface InsuranceState {
-  selectedPlan: InsurancePlan
-  setSelectedPlan: (plan: InsurancePlan) => void
+  selectedPlan: InsurancePlan;
+  setSelectedPlan: (plan: InsurancePlan) => void;
 }
 
 export const useInsuranceStore = create<InsuranceState>((set) => ({
-  selectedPlan: 'basic',
+  selectedPlan: "medical",
   setSelectedPlan: (plan) => set({ selectedPlan: plan }),
-}))
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -442,12 +442,14 @@
     "dashboard": {
       "version": "0.1.0",
       "dependencies": {
+        "@react-spring/three": "^10.0.1",
         "@react-three/drei": "^10.3.0",
         "@react-three/fiber": "^9.0.0-alpha.8",
         "@reown/appkit": "^1.7.6",
         "@reown/appkit-adapter-wagmi": "^1.7.6",
         "@swc/helpers": "^0.5.17",
         "@tanstack/react-query": "^5.77.1",
+        "@use-gesture/react": "^10.3.1",
         "ethers": "^6.14.1",
         "leva": "^0.10.0",
         "next": "15.3.2",
@@ -471,6 +473,23 @@
         "eslint-config-next": "15.3.2",
         "tailwindcss": "^4",
         "typescript": "^5"
+      }
+    },
+    "dashboard/node_modules/@react-spring/three": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/three/-/three-10.0.1.tgz",
+      "integrity": "sha512-JAgA573EqG1WkDGameWv0HYlPL5KYwVCRhXroBq5Ed0Chc9xXuAZU8fyNg9/uup8Pc32iGSW0PHRt0msvPNg+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.0.1",
+        "@react-spring/core": "~10.0.1",
+        "@react-spring/shared": "~10.0.1",
+        "@react-spring/types": "~10.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=6.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "three": ">=0.126"
       }
     },
     "dashboard/node_modules/@react-three/drei": {
@@ -6865,6 +6884,62 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       }
+    },
+    "node_modules/@react-spring/animated": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-10.0.1.tgz",
+      "integrity": "sha512-BGL3hA66Y8Qm3KmRZUlfG/mFbDPYajgil2/jOP0VXf2+o2WPVmcDps/eEgdDqgf5Pv9eBbyj7LschLMuSjlW3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~10.0.1",
+        "@react-spring/types": "~10.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-10.0.1.tgz",
+      "integrity": "sha512-KaMMsN1qHuVTsFpg/5ajAVye7OEqhYbCq0g4aKM9bnSZlDBBYpO7Uf+9eixyXN8YEbF+YXaYj9eoWDs+npZ+sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~10.0.1",
+        "@react-spring/shared": "~10.0.1",
+        "@react-spring/types": "~10.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-10.0.1.tgz",
+      "integrity": "sha512-UrzG/d6Is+9i0aCAjsjWRqIlFFiC4lFqFHrH63zK935z2YDU95TOFio4VKGISJ5SG0xq4ULy7c1V3KU+XvL+Yg==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-10.0.1.tgz",
+      "integrity": "sha512-KR2tmjDShPruI/GGPfAZOOLvDgkhFseabjvxzZFFggJMPkyICLjO0J6mCIoGtdJSuHywZyc4Mmlgi+C88lS00g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~10.0.1",
+        "@react-spring/types": "~10.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-10.0.1.tgz",
+      "integrity": "sha512-Fk1wYVAKL+ZTYK+4YFDpHf3Slsy59pfFFvnnTfRjQQFGlyIo4VejPtDs3CbDiuBjM135YztRyZjIH2VbycB+ZQ==",
+      "license": "MIT"
     },
     "node_modules/@reown/appkit": {
       "version": "1.7.7",


### PR DESCRIPTION
## Summary
- add an interactive InsuranceSlider component that lets users slide through plans
- display the new slider in the Insurance page

## Testing
- `npm --prefix dashboard run lint` *(fails: `next` not found)*
- `npm --prefix backend test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ba7d91ac832091c527407c2367ea