### PR TITLE
Fix Swagger file upload fields

### DIFF
--- a/backend/src/api/claim/claim.controller.ts
+++ b/backend/src/api/claim/claim.controller.ts
@@ -16,17 +16,38 @@ import { UpdateClaimDto } from './dto/requests/update-claim.dto';
 import { CreateClaimDto } from './dto/requests/create-claim.dto';
 import { AuthenticatedRequest } from 'src/supabase/types/express';
 import { AuthGuard } from '../auth/auth.guard';
-import { ApiBearerAuth } from '@nestjs/swagger';
-import { FileInterceptor } from '@nestjs/platform-express';
+import { ApiBearerAuth, ApiBody, ApiConsumes, ApiTags } from '@nestjs/swagger';
+import { FilesInterceptor } from '@nestjs/platform-express';
 
 @Controller('claim')
 @ApiBearerAuth('supabase-auth')
+@ApiTags('Claims')
 export class ClaimController {
   constructor(private readonly claimService: ClaimService) {}
 
   @Post()
-  @UseInterceptors(FileInterceptor('documents'))
+  @UseInterceptors(FilesInterceptor('documents'))
   @UseGuards(AuthGuard)
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    description: 'Create a claim with optional documents',
+    schema: {
+      type: 'object',
+      properties: {
+        policy_id: { type: 'integer' },
+        claim_type: { type: 'string' },
+        amount: { type: 'number' },
+        description: { type: 'string' },
+        documents: {
+          type: 'array',
+          items: {
+            type: 'string',
+            format: 'binary',
+          },
+        },
+      },
+    },
+  })
   create(
     @Body() createClaimDto: CreateClaimDto,
     @Req() req: AuthenticatedRequest,


### PR DESCRIPTION
## Summary
- enable swagger docs for uploading claim documents

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687711a60ee0832091c09e5e716236b3