### PR TITLE
Integrate supabase storage utils into policy service

### DIFF
--- a/backend/src/api/policy/dto/responses/policy.dto.ts
+++ b/backend/src/api/policy/dto/responses/policy.dto.ts
@@ -1,0 +1,52 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PolicyDocumentResponseDto {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty()
+  policy_id!: number;
+
+  @ApiProperty({
+    description: 'Signed Supabase URL for accessing this document',
+  })
+  signedUrl!: string;
+}
+
+export class PolicyResponseDto {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty()
+  category!: string;
+
+  @ApiProperty()
+  provider!: string;
+
+  @ApiProperty()
+  coverage!: number;
+
+  @ApiProperty()
+  premium!: string;
+
+  @ApiProperty()
+  rating!: number;
+
+  @ApiProperty()
+  popular!: boolean;
+
+  @ApiProperty({ required: false })
+  description!: string | null;
+
+  @ApiProperty({ type: [String] })
+  features!: string[];
+
+  @ApiProperty({ type: [PolicyDocumentResponseDto] })
+  documents!: PolicyDocumentResponseDto[];
+}

--- a/backend/src/api/policy/policy.controller.ts
+++ b/backend/src/api/policy/policy.controller.ts
@@ -19,6 +19,8 @@ import { AuthenticatedRequest } from 'src/supabase/types/express';
 import { AuthGuard } from '../auth/auth.guard';
 import { ApiBearerAuth, ApiConsumes, ApiQuery } from '@nestjs/swagger';
 import { FilesInterceptor } from '@nestjs/platform-express';
+import { ApiCommonResponse, CommonResponseDto } from 'src/common/common.dto';
+import { PolicyResponseDto } from './dto/responses/policy.dto';
 
 @Controller('policy')
 @ApiBearerAuth('supabase-auth')
@@ -33,12 +35,13 @@ export class PolicyController {
     @Body() createPolicyDto: CreatePolicyDto,
     @Req() req: AuthenticatedRequest,
     @UploadedFiles() files: Array<Express.Multer.File>,
-  ) {
-    return await this.policyService.create(createPolicyDto, req, files);
+  ): Promise<CommonResponseDto> {
+    return this.policyService.create(createPolicyDto, req, files);
   }
 
   @Get()
   @UseGuards(AuthGuard)
+  @ApiCommonResponse(PolicyResponseDto, true, 'Get all policies')
   findAll(
     @Req() req: AuthenticatedRequest,
     @Query('page') page = '1',
@@ -47,7 +50,7 @@ export class PolicyController {
     @Query('search') search?: string,
     @Query('sortBy') sortBy = 'id',
     @Query('sortOrder') sortOrder: 'asc' | 'desc' = 'asc',
-  ) {
+  ): Promise<CommonResponseDto<PolicyResponseDto[]>> {
     return this.policyService.findAll(
       req,
       +page,
@@ -61,23 +64,32 @@ export class PolicyController {
 
   @Get(':id')
   @UseGuards(AuthGuard)
-  findOne(@Param('id') id: string, @Req() req: AuthenticatedRequest) {
+  @ApiCommonResponse(PolicyResponseDto, false, 'Get policy with signed URLs')
+  findOne(
+    @Param('id') id: string,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<CommonResponseDto<PolicyResponseDto>> {
     return this.policyService.findOne(+id, req);
   }
 
   @Patch(':id')
   @UseGuards(AuthGuard)
+  @ApiCommonResponse(PolicyResponseDto, false, 'Update policy')
   update(
     @Param('id') id: string,
     @Body() updatePolicyDto: UpdatePolicyDto,
     @Req() req: AuthenticatedRequest,
-  ) {
+  ): Promise<CommonResponseDto> {
     return this.policyService.update(+id, updatePolicyDto, req);
   }
 
   @Delete(':id')
   @UseGuards(AuthGuard)
-  remove(@Param('id') id: string, @Req() req: AuthenticatedRequest) {
+  @ApiCommonResponse(PolicyResponseDto, false, 'Remove policy')
+  remove(
+    @Param('id') id: string,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<CommonResponseDto> {
     return this.policyService.remove(+id, req);
   }
 }


### PR DESCRIPTION
## Summary
- add policy response DTOs
- refactor policy service to use shared supabase storage helpers
- update controller to expose signed URLs and common responses

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b30f155a0832086602ad3e95d4513