### PR TITLE
Add coverage query dto and improve search

### DIFF
--- a/backend/src/api/coverage/coverage.controller.ts
+++ b/backend/src/api/coverage/coverage.controller.ts
@@ -15,6 +15,7 @@ import {
   CoverageStatus,
   CreateCoverageDto,
 } from './dto/requests/create-coverage.dto';
+import { FindCoverageQueryDto } from './dto/responses/coverage-query.dto';
 import { UpdateCoverageDto } from './dto/requests/update-coverage.dto';
 import { AuthGuard } from '../auth/auth.guard';
 import { ApiBearerAuth } from '@nestjs/swagger';
@@ -37,25 +38,10 @@ export class CoverageController {
   @Get()
   @UseGuards(AuthGuard)
   findAll(
-    @Req() req: AuthenticatedRequest, // Authenticated request to access Supabase
-    @Query('page') page = '1',
-    @Query('limit') limit = '5',
-    @Query('category') category?: string,
-    @Query('search') search?: string,
-    @Query('status') status?: CoverageStatus,
-    @Query('sortBy') sortBy = 'id',
-    @Query('sortOrder') sortOrder: 'asc' | 'desc' = 'asc',
+    @Req() req: AuthenticatedRequest,
+    @Query() query: FindCoverageQueryDto,
   ) {
-    return this.coverageService.findAll(
-      req,
-      +page,
-      +limit,
-      category,
-      search,
-      status,
-      sortBy,
-      sortOrder,
-    );
+    return this.coverageService.findAll(req, query);
   }
 
   @Get(':id')

--- a/backend/src/api/coverage/dto/responses/coverage-query.dto.ts
+++ b/backend/src/api/coverage/dto/responses/coverage-query.dto.ts
@@ -1,0 +1,36 @@
+import { IsEnum, IsIn, IsOptional, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { PaginatedQueryDto } from 'src/common/paginated-query.dto';
+import { CoverageStatus } from '../requests/create-coverage.dto';
+
+export class FindCoverageQueryDto extends PaginatedQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by policy category' })
+  @IsOptional()
+  @IsString()
+  category?: string;
+
+  @ApiPropertyOptional({
+    description: 'Search keyword for policy name or description',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({ enum: CoverageStatus })
+  @IsOptional()
+  @IsEnum(CoverageStatus)
+  status?: CoverageStatus;
+
+  @ApiPropertyOptional({
+    default: 'id',
+    enum: ['id', 'start_date', 'utilization_rate'],
+  })
+  @IsOptional()
+  @IsIn(['id', 'start_date', 'utilization_rate'])
+  sortBy: string = 'id';
+
+  @ApiPropertyOptional({ default: 'asc', enum: ['asc', 'desc'] })
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  sortOrder: 'asc' | 'desc' = 'asc';
+}


### PR DESCRIPTION
## Summary
- introduce `FindCoverageQueryDto` to collect query params for coverage search
- update coverage controller to use the new DTO
- update coverage service to properly join `policies` table and filter at the DB layer

## Testing
- `npm --prefix backend run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b64f409a48320931b31c4b897d92d