### PR TITLE
Add CoverageResponseDto

### DIFF
--- a/backend/src/api/coverage/coverage.controller.ts
+++ b/backend/src/api/coverage/coverage.controller.ts
@@ -17,6 +17,8 @@ import { UpdateCoverageDto } from './dto/requests/update-coverage.dto';
 import { AuthGuard } from '../auth/auth.guard';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { AuthenticatedRequest } from 'src/supabase/types/express';
+import { ApiCommonResponse, CommonResponseDto } from 'src/common/common.dto';
+import { CoverageResponseDto } from './dto/responses/coverage.dto';
 
 @Controller('coverage')
 @ApiBearerAuth('supabase-auth')
@@ -34,17 +36,21 @@ export class CoverageController {
 
   @Get()
   @UseGuards(AuthGuard)
+  @ApiCommonResponse(CoverageResponseDto, true, 'Get all coverages')
   findAll(
     @Req() req: AuthenticatedRequest,
     @Query() query: FindCoverageQueryDto,
-  ) {
+  ): Promise<CommonResponseDto<CoverageResponseDto[]>> {
     return this.coverageService.findAll(req, query);
   }
 
   @Get(':id')
   @UseGuards(AuthGuard)
-  @Get(':id')
-  findOne(@Param('id') id: string, @Req() req: AuthenticatedRequest) {
+  @ApiCommonResponse(CoverageResponseDto, false, 'Get coverage')
+  findOne(
+    @Param('id') id: string,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<CommonResponseDto<CoverageResponseDto>> {
     return this.coverageService.findOne(+id, req);
   }
 

--- a/backend/src/api/coverage/coverage.service.ts
+++ b/backend/src/api/coverage/coverage.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { CreateCoverageDto } from './dto/requests/create-coverage.dto';
 import { FindCoverageQueryDto } from './dto/responses/coverage-query.dto';
+import { CoverageResponseDto } from './dto/responses/coverage.dto';
 // import { SupabaseService } from 'src/supabase/supabase.service';
 import { UpdateCoverageDto } from './dto/requests/update-coverage.dto';
 import { AuthenticatedRequest } from 'src/supabase/types/express';
@@ -50,7 +51,10 @@ export class CoverageService {
     });
   }
 
-  async findAll(req: AuthenticatedRequest, query: FindCoverageQueryDto) {
+  async findAll(
+    req: AuthenticatedRequest,
+    query: FindCoverageQueryDto,
+  ): Promise<CommonResponseDto<CoverageResponseDto[]>> {
     const supabase = req.supabase;
     const offset = ((query.page || 1) - 1) * (query.limit || 5);
 
@@ -105,7 +109,10 @@ export class CoverageService {
     });
   }
 
-  async findOne(id: number, req: AuthenticatedRequest) {
+  async findOne(
+    id: number,
+    req: AuthenticatedRequest,
+  ): Promise<CommonResponseDto<CoverageResponseDto>> {
     const { data: coverage, error: findOneError } = await req.supabase
       .from('coverage')
       .select('*')

--- a/backend/src/api/coverage/dto/responses/coverage.dto.ts
+++ b/backend/src/api/coverage/dto/responses/coverage.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CoverageStatus } from '../../requests/create-coverage.dto';
+
+export class CoveragePolicyDto {
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty({ required: false })
+  description!: string | null;
+
+  @ApiProperty()
+  category!: string;
+}
+
+export class CoverageResponseDto {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty({ required: false })
+  policy_id!: number | null;
+
+  @ApiProperty({ required: false })
+  user_id!: string | null;
+
+  @ApiProperty({ enum: CoverageStatus })
+  status!: CoverageStatus;
+
+  @ApiProperty()
+  utilization_rate!: number;
+
+  @ApiProperty()
+  start_date!: string;
+
+  @ApiProperty()
+  end_date!: string;
+
+  @ApiProperty()
+  next_payment_date!: string;
+
+  @ApiProperty({ type: () => CoveragePolicyDto })
+  policies?: CoveragePolicyDto;
+}


### PR DESCRIPTION
## Summary
- implement CoverageResponseDto and nested policy info
- type coverage service responses with CoverageResponseDto
- document coverage endpoints with ApiCommonResponse

## Testing
- `npm test` *(fails: ENOAUDIT / missing deps due to offline environment)*
- `npm run lint` *(fails: missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_687b69c703508320bb0932d9547290a4