### PR TITLE
Add user response DTOs and integrate ApiCommonResponse

### DIFF
--- a/backend/src/api/user/dto/respond/user-stats.dto.ts
+++ b/backend/src/api/user/dto/respond/user-stats.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserStatsResponseDto {
+  @ApiProperty()
+  totalUsers!: number;
+
+  @ApiProperty()
+  activeUsers!: number;
+
+  @ApiProperty()
+  policyholders!: number;
+
+  @ApiProperty()
+  insuranceAdmins!: number;
+
+  constructor(dto: Partial<UserStatsResponseDto>) {
+    Object.assign(this, dto);
+  }
+}

--- a/backend/src/api/user/dto/respond/user.dto.ts
+++ b/backend/src/api/user/dto/respond/user.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AdminDetails, PolicyholderDetails, UserRole, UserStatus } from '../requests/create.dto';
+
+export class UserResponseDto {
+  @ApiProperty()
+  user_id!: string;
+
+  @ApiProperty()
+  email!: string;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty({ enum: UserRole })
+  role!: UserRole;
+
+  @ApiProperty({ required: false, nullable: true })
+  phone!: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  bio!: string | null;
+
+  @ApiProperty({ enum: UserStatus })
+  status!: UserStatus;
+
+  @ApiProperty({ required: false })
+  lastLogin!: string | null | undefined;
+
+  @ApiProperty({ required: false })
+  joinedAt!: string | null | undefined;
+
+  @ApiProperty({ required: false, type: 'object' })
+  details?: AdminDetails | PolicyholderDetails | null;
+
+  constructor(dto: Partial<UserResponseDto>) {
+    Object.assign(this, dto);
+  }
+}

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -5,6 +5,9 @@ import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from '../auth/auth.guard';
 import { Role } from '../auth/role.decorator';
 import { RolesGuard } from '../auth/role.guard';
+import { ApiCommonResponse, CommonResponseDto } from 'src/common/common.dto';
+import { UserResponseDto } from './dto/respond/user.dto';
+import { UserStatsResponseDto } from './dto/respond/user-stats.dto';
 
 @ApiTags('Users')
 @Controller('users')
@@ -15,22 +18,30 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Get()
-  async findAll(): Promise<any> {
+  @ApiCommonResponse(UserResponseDto, true, 'Get all users')
+  async findAll(): Promise<CommonResponseDto<UserResponseDto[]>> {
     return this.userService.getAllUsers();
   }
 
   @Get('stats')
-  async getStats() {
+  @ApiCommonResponse(UserStatsResponseDto, false, 'Get user statistics')
+  async getStats(): Promise<CommonResponseDto<UserStatsResponseDto>> {
     return this.userService.getUserStats();
   }
 
   @Get(':id')
-  async findOne(@Param('id') id: string): Promise<any> {
+  @ApiCommonResponse(UserResponseDto, false, 'Get user by id')
+  async findOne(
+    @Param('id') id: string,
+  ): Promise<CommonResponseDto<UserResponseDto>> {
     return this.userService.getUserById(id);
   }
 
   @Post()
-  async create(@Body() body: CreateUserDto): Promise<any> {
+  @ApiCommonResponse(UserResponseDto, false, 'Create user')
+  async create(
+    @Body() body: CreateUserDto,
+  ): Promise<CommonResponseDto<UserResponseDto>> {
     return this.userService.createUser(body);
   }
 }


### PR DESCRIPTION
## Summary
- implement `UserResponseDto` and `UserStatsResponseDto`
- refactor `UserService` to return `CommonResponseDto` wrapped results
- annotate `UserController` routes with `ApiCommonResponse`

## Testing
- `npm test --silent --prefix backend` *(fails: jest not found)*
- `npm run lint --silent --prefix backend` *(fails: missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_687e1333486c8320a3f5a886f729a68e