### PR TITLE
Fix duplicate DTO names

### DIFF
--- a/backend/src/api/auth/auth.controller.ts
+++ b/backend/src/api/auth/auth.controller.ts
@@ -14,7 +14,7 @@ import { LoginResponseDto } from './dto/responses/login.dto';
 import { AuthGuard } from './auth.guard';
 import { ApiCommonResponse, CommonResponseDto } from '../../common/common.dto';
 import { AuthenticatedRequest } from 'src/supabase/types/express';
-import { UserResponseDto } from './dto/responses/user.dto';
+import { AuthUserResponseDto } from './dto/responses/auth-user.dto';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -36,11 +36,11 @@ export class AuthController {
 
   @UseGuards(AuthGuard)
   @Get('me')
-  @ApiCommonResponse(UserResponseDto, false, 'User login')
+  @ApiCommonResponse(AuthUserResponseDto, false, 'User login')
   @ApiBearerAuth('supabase-auth')
   async getMe(
     @Request() req: AuthenticatedRequest,
-  ): Promise<CommonResponseDto<UserResponseDto>> {
+  ): Promise<CommonResponseDto<AuthUserResponseDto>> {
     return this.authService.getMe(req);
   }
 }

--- a/backend/src/api/auth/auth.service.ts
+++ b/backend/src/api/auth/auth.service.ts
@@ -9,7 +9,7 @@ import { LoginDto } from './dto/requests/login.dto';
 import { LoginResponseDto } from './dto/responses/login.dto';
 import { CommonResponseDto } from '../../common/common.dto';
 import { AuthenticatedRequest } from 'src/supabase/types/express';
-import { UserResponseDto } from './dto/responses/user.dto';
+import { AuthUserResponseDto } from './dto/responses/auth-user.dto';
 import { UserRole } from '../user/dto/requests/create.dto';
 import { parseAppMetadata, parseUserMetadata } from 'src/utils/auth-metadata';
 
@@ -148,7 +148,7 @@ export class AuthService {
     return new CommonResponseDto({
       statusCode: 200,
       message: 'Authenticated User retrieved successfully',
-      data: new UserResponseDto({
+      data: new AuthUserResponseDto({
         id: data.user.id,
         email: data.user.email ?? '',
         email_verified: metadata.email_verified ?? false,

--- a/backend/src/api/auth/dto/responses/auth-user.dto.ts
+++ b/backend/src/api/auth/dto/responses/auth-user.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class UserResponseDto {
+export class AuthUserResponseDto {
   @ApiProperty()
   id!: string;
 
@@ -22,7 +22,7 @@ export class UserResponseDto {
   @ApiProperty()
   provider!: string;
 
-  constructor(dto: UserResponseDto) {
+  constructor(dto: AuthUserResponseDto) {
     Object.assign(this, dto);
   }
 }

--- a/backend/src/api/auth/dto/responses/login.dto.ts
+++ b/backend/src/api/auth/dto/responses/login.dto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { UserResponseDto } from './user.dto';
+import { AuthUserResponseDto } from './auth-user.dto';
 
 export class LoginResponseDto {
   @ApiProperty()
   accessToken!: string;
 
-  @ApiProperty({ type: () => UserResponseDto })
-  user!: UserResponseDto;
+  @ApiProperty({ type: () => AuthUserResponseDto })
+  user!: AuthUserResponseDto;
 
   constructor(dto: LoginResponseDto) {
     Object.assign(this, dto);

--- a/backend/swagger-spec.json
+++ b/backend/swagger-spec.json
@@ -84,7 +84,7 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "#/components/schemas/UserResponseDto"
+                          "$ref": "#/components/schemas/AuthUserResponseDto"
                         }
                       }
                     }
@@ -1221,6 +1221,27 @@
           "status"
         ]
       },
+      "AuthUserResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "email": { "type": "string" },
+          "email_verified": { "type": "boolean" },
+          "username": { "type": "string" },
+          "role": { "type": "string" },
+          "lastSignInAt": { "type": "string" },
+          "provider": { "type": "string" }
+        },
+        "required": [
+          "id",
+          "email",
+          "email_verified",
+          "username",
+          "role",
+          "lastSignInAt",
+          "provider"
+        ]
+      },
       "LoginResponseDto": {
         "type": "object",
         "properties": {
@@ -1228,7 +1249,7 @@
             "type": "string"
           },
           "user": {
-            "$ref": "#/components/schemas/UserResponseDto"
+            "$ref": "#/components/schemas/AuthUserResponseDto"
           }
         },
         "required": [

--- a/dashboard/src/api-client/api.ts
+++ b/dashboard/src/api-client/api.ts
@@ -30,7 +30,7 @@ export interface CommonResponseDto {
   data?: CommonResponseDtoData;
 }
 
-export interface UserResponseDto {
+export interface AuthUserResponseDto {
   id: string;
   email: string;
   email_verified: boolean;
@@ -42,7 +42,7 @@ export interface UserResponseDto {
 
 export interface LoginResponseDto {
   accessToken: string;
-  user: UserResponseDto;
+  user: AuthUserResponseDto;
 }
 
 export interface LoginDto {
@@ -83,7 +83,7 @@ export type AuthControllerLogin200 = CommonResponseDto &
   AuthControllerLogin200AllOf;
 
 export type AuthControllerGetMe200AllOf = {
-  data?: UserResponseDto;
+  data?: AuthUserResponseDto;
 };
 
 export type AuthControllerGetMe200 = CommonResponseDto &


### PR DESCRIPTION
## Summary
- rename `UserResponseDto` in auth module to `AuthUserResponseDto`
- update Swagger spec and API client

## Testing
- `npm --prefix backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e1a35b7c8832081172b65a3ab9852