### PR TITLE
Add PDF claim type extraction service

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -33,7 +33,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "supabase": "^2.31.4",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "pdf-parse": "^1.1.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/backend/src/api/pdf-claim-extractor/dto/extracted-claim-types.dto.ts
+++ b/backend/src/api/pdf-claim-extractor/dto/extracted-claim-types.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ClaimTypeBenefitDto {
+  @ApiProperty()
+  type!: string;
+
+  @ApiProperty()
+  maxBenefit!: string;
+}
+
+export class ExtractedClaimTypesDto {
+  @ApiProperty()
+  policyType!: string;
+
+  @ApiProperty({ type: () => [ClaimTypeBenefitDto] })
+  claimTypes!: ClaimTypeBenefitDto[];
+}

--- a/backend/src/api/pdf-claim-extractor/pdf-claim-extractor.controller.ts
+++ b/backend/src/api/pdf-claim-extractor/pdf-claim-extractor.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { PdfClaimExtractorService } from './pdf-claim-extractor.service';
+import { CommonResponseDto } from 'src/common/common.dto';
+import { ExtractedClaimTypesDto } from './dto/extracted-claim-types.dto';
+
+@Controller('claim-type-extractor')
+export class PdfClaimExtractorController {
+  constructor(private readonly service: PdfClaimExtractorService) {}
+
+  @Post()
+  @UseInterceptors(FileInterceptor('file'))
+  async extract(@UploadedFile() file: Express.Multer.File): Promise<CommonResponseDto<ExtractedClaimTypesDto>> {
+    const data = await this.service.extractClaimTypes(file);
+    return new CommonResponseDto({
+      statusCode: 200,
+      message: 'Extraction successful',
+      data,
+    });
+  }
+}

--- a/backend/src/api/pdf-claim-extractor/pdf-claim-extractor.module.ts
+++ b/backend/src/api/pdf-claim-extractor/pdf-claim-extractor.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { PdfClaimExtractorController } from './pdf-claim-extractor.controller';
+import { PdfClaimExtractorService } from './pdf-claim-extractor.service';
+
+@Module({
+  controllers: [PdfClaimExtractorController],
+  providers: [PdfClaimExtractorService],
+})
+export class PdfClaimExtractorModule {}

--- a/backend/src/api/pdf-claim-extractor/pdf-claim-extractor.service.ts
+++ b/backend/src/api/pdf-claim-extractor/pdf-claim-extractor.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import * as pdfParse from 'pdf-parse';
+import { ExtractedClaimTypesDto, ClaimTypeBenefitDto } from './dto/extracted-claim-types.dto';
+
+@Injectable()
+export class PdfClaimExtractorService {
+  async extractClaimTypes(file: Express.Multer.File): Promise<ExtractedClaimTypesDto> {
+    const data = await pdfParse(file.buffer);
+    const text = data.text || '';
+    return this.parseText(text);
+  }
+
+  private parseText(text: string): ExtractedClaimTypesDto {
+    let policyType = 'UNKNOWN';
+    const policyMatch = text.match(/Policy\s*Type\s*[:\-]?\s*(\w+)/i);
+    if (policyMatch) {
+      policyType = policyMatch[1].toUpperCase();
+    }
+
+    const claimTypes: ClaimTypeBenefitDto[] = [];
+    const lines = text.split(/\r?\n/);
+    for (const line of lines) {
+      const match = line.match(/^(Trip Cancellation|Trip Delay|Baggage Delay|Lost Luggage|Medical(?: \w+)?|[A-Z][A-Za-z ]+)\s*[-–:]?\s*(.+)$/i);
+      if (match) {
+        claimTypes.push({ type: match[1].trim(), maxBenefit: match[2].trim() });
+      }
+    }
+
+    return { policyType, claimTypes };
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { ClaimModule } from './api/claim/claim.module';
 import { MulterConfigModule } from './common/multer.config';
 import { PolicyModule } from './api/policy/policy.module';
 import { CoverageModule } from './api/coverage/coverage.module';
+import { PdfClaimExtractorModule } from './api/pdf-claim-extractor/pdf-claim-extractor.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { CoverageModule } from './api/coverage/coverage.module';
     PolicyModule,
     MulterConfigModule,
     CoverageModule,
+    PdfClaimExtractorModule,
   ],
 
   controllers: [AppController],


### PR DESCRIPTION
## Summary
- add pdf-claim-extractor module with controller and service
- wire pdf-claim-extractor module into `AppModule`
- declare `pdf-parse` dependency in backend

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e1e46dc788320988d1e2f755543b1