### PR TITLE
Implement user update functionality

### DIFF
--- a/backend/src/api/user/dto/requests/update.dto.ts
+++ b/backend/src/api/user/dto/requests/update.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateUserDto } from './create.dto';
+
+export class UpdateUserDto extends PartialType(CreateUserDto) {}

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -1,6 +1,7 @@
-import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Patch, UseGuards } from '@nestjs/common';
 import { UserService } from './user.service';
 import { CreateUserDto } from './dto/requests/create.dto';
+import { UpdateUserDto } from './dto/requests/update.dto';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from '../auth/auth.guard';
 import { Role } from '../auth/role.decorator';
@@ -43,5 +44,14 @@ export class UserController {
     @Body() body: CreateUserDto,
   ): Promise<CommonResponseDto<UserResponseDto>> {
     return this.userService.createUser(body);
+  }
+
+  @Patch(':id')
+  @ApiCommonResponse(UserResponseDto, false, 'Update user')
+  async update(
+    @Param('id') id: string,
+    @Body() body: UpdateUserDto,
+  ): Promise<CommonResponseDto<UserResponseDto>> {
+    return this.userService.updateUser(id, body);
   }
 }


### PR DESCRIPTION
## Summary
- add DTO for updating users
- implement `updateUser` service method
- expose update endpoint in user controller

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm run build --prefix backend` *(fails: nest not found)*
- `npx tsc -p backend/tsconfig.json` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_687e50ebbd208320a323b62f03a2f7c2