### PR TITLE
Implement useAuth hook and integrate with auth forms

### DIFF
--- a/dashboard/app/auth/login/page.tsx
+++ b/dashboard/app/auth/login/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
+import useAuth from "@/app/hooks/useAuth";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -9,6 +11,8 @@ import { Shield, Eye, EyeOff, ArrowLeft } from "lucide-react";
 import Link from "next/link";
 
 export default function LoginPage() {
+  const router = useRouter();
+  const { login, isLoggingIn, loginError } = useAuth();
   const [showPassword, setShowPassword] = useState(false);
   const [formData, setFormData] = useState({
     email: "",
@@ -16,10 +20,14 @@ export default function LoginPage() {
     rememberMe: false,
   });
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    console.log("Login attempt:", formData);
-    // Handle login logic here
+    try {
+      await login({ email: formData.email, password: formData.password });
+      router.push("/");
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   return (
@@ -131,10 +139,16 @@ export default function LoginPage() {
 
               <Button
                 type="submit"
+                disabled={isLoggingIn}
                 className="w-full bg-gradient-to-r from-emerald-500 via-teal-500 to-emerald-500 text-white transform transition-all duration-300 hover:scale-105 hover:shadow-xl active:scale-95 py-3"
               >
                 Sign In
               </Button>
+              {loginError && (
+                <p className="text-red-500 text-sm mt-2 text-center">
+                  {(loginError as Error).message || "Login failed"}
+                </p>
+              )}
             </form>
 
             <div className="mt-6 text-center">

--- a/dashboard/app/hooks/useAuth.ts
+++ b/dashboard/app/hooks/useAuth.ts
@@ -1,0 +1,66 @@
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  useAuthControllerLogin,
+  useAuthControllerRegister,
+  useAuthControllerGetMe,
+  getAuthControllerGetMeQueryKey,
+  type LoginDto,
+  type RegisterDto,
+} from "@/app/api";
+
+export default function useAuth() {
+  const queryClient = useQueryClient();
+
+  const loginMutation = useAuthControllerLogin();
+  const registerMutation = useAuthControllerRegister();
+
+  const meQuery = useAuthControllerGetMe(
+    {
+      query: {
+        enabled:
+          typeof window !== "undefined" &&
+          !!localStorage.getItem("access_token"),
+      },
+    },
+    queryClient,
+  );
+
+  const login = useCallback(
+    async (credentials: LoginDto) => {
+      const res = await loginMutation.mutateAsync({ data: credentials });
+      const token = res.data?.accessToken;
+      if (token) {
+        localStorage.setItem("access_token", token);
+        await queryClient.invalidateQueries(getAuthControllerGetMeQueryKey());
+      }
+      return res;
+    },
+    [loginMutation, queryClient],
+  );
+
+  const register = useCallback(
+    async (payload: RegisterDto) => {
+      return registerMutation.mutateAsync({ data: payload });
+    },
+    [registerMutation],
+  );
+
+  const logout = useCallback(() => {
+    localStorage.removeItem("access_token");
+    queryClient.removeQueries({ queryKey: getAuthControllerGetMeQueryKey() });
+  }, [queryClient]);
+
+  return {
+    login,
+    register,
+    logout,
+    user: meQuery.data?.data,
+    isAuthenticated: !!meQuery.data?.data,
+    isLoadingUser: meQuery.isLoading,
+    loginError: loginMutation.error,
+    isLoggingIn: loginMutation.isPending,
+    registerError: registerMutation.error,
+    isRegistering: registerMutation.isPending,
+  };
+}


### PR DESCRIPTION
## Summary
- implement `useAuth` hook to wrap auth API
- wire up login form with new hook
- hook up policyholder registration with API

## Testing
- `npm --prefix dashboard run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881b5a23d7c8320bba592d4aa5eca41