### PR TITLE
Add role based auth guard

### DIFF
--- a/dashboard/app/(admin)/layout.tsx
+++ b/dashboard/app/(admin)/layout.tsx
@@ -1,5 +1,6 @@
 import { Navbar } from '@/components/shared/Navbar';
 import { Footer } from '@/components/shared/Footer';
+import AuthGuard from '@/components/shared/AuthGuard';
 
 export default function AdminLayout({
   children,
@@ -7,12 +8,14 @@ export default function AdminLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-teal-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900">
-      <Navbar role="admin" />
-      <main className="pt-16">
-        {children}
-      </main>
-      <Footer />
-    </div>
+    <AuthGuard role="admin">
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-teal-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900">
+        <Navbar role="admin" />
+        <main className="pt-16">
+          {children}
+        </main>
+        <Footer />
+      </div>
+    </AuthGuard>
   );
 }

--- a/dashboard/app/(policyholder)/layout.tsx
+++ b/dashboard/app/(policyholder)/layout.tsx
@@ -1,5 +1,6 @@
 import { Navbar } from '@/components/shared/Navbar';
 import { Footer } from '@/components/shared/Footer';
+import AuthGuard from '@/components/shared/AuthGuard';
 
 export default function PolicyholderLayout({
   children,
@@ -7,12 +8,14 @@ export default function PolicyholderLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-teal-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900">
-      <Navbar role="policyholder" />
-      <main className="pt-16">
-        {children}
-      </main>
-      <Footer />
-    </div>
+    <AuthGuard role="policyholder">
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-teal-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900">
+        <Navbar role="policyholder" />
+        <main className="pt-16">
+          {children}
+        </main>
+        <Footer />
+      </div>
+    </AuthGuard>
   );
 }

--- a/dashboard/app/(system-admin)/layout.tsx
+++ b/dashboard/app/(system-admin)/layout.tsx
@@ -1,5 +1,6 @@
 import { Navbar } from '@/components/shared/Navbar';
 import { Footer } from '@/components/shared/Footer';
+import AuthGuard from '@/components/shared/AuthGuard';
 
 export default function SystemAdminLayout({
   children,
@@ -7,12 +8,14 @@ export default function SystemAdminLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-teal-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900">
-      <Navbar role="system-admin" />
-      <main className="pt-16">
-        {children}
-      </main>
-      <Footer />
-    </div>
+    <AuthGuard role="system-admin">
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-teal-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900">
+        <Navbar role="system-admin" />
+        <main className="pt-16">
+          {children}
+        </main>
+        <Footer />
+      </div>
+    </AuthGuard>
   );
 }

--- a/dashboard/components/shared/AuthGuard.tsx
+++ b/dashboard/components/shared/AuthGuard.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import useAuth from '@/app/hooks/useAuth';
+
+interface AuthGuardProps {
+  children: React.ReactNode;
+  role?: 'policyholder' | 'admin' | 'system-admin';
+}
+
+export default function AuthGuard({ children, role }: AuthGuardProps) {
+  const router = useRouter();
+  const { user, isAuthenticated, isLoadingUser } = useAuth();
+
+  useEffect(() => {
+    if (!isLoadingUser) {
+      if (!isAuthenticated) {
+        router.replace('/auth/login');
+      } else if (role && user?.role !== role) {
+        router.replace('/');
+      }
+    }
+  }, [isAuthenticated, isLoadingUser, role, router, user]);
+
+  if (!isAuthenticated || isLoadingUser || (role && user?.role !== role)) {
+    return null;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- add a new `AuthGuard` component
- wrap admin, policyholder and system-admin layouts with role based guard

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix dashboard run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881c1accad48320acd4aef70ba48d47