### PR TITLE
Fix dynamic layout and error pages

### DIFF
--- a/dashboard/app/error.tsx
+++ b/dashboard/app/error.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+export default function GlobalError({ error }: { error: Error }) {
+  return (
+    <html>
+      <body className="flex h-screen items-center justify-center">
+        <div>Something went wrong: {error.message}</div>
+      </body>
+    </html>
+  );
+}

--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -6,6 +6,11 @@ import Web3Providers from "@/app/providers/Web3Providers"; // ✅ import it
 import GlobalNavbar from "@/components/shared/GlobalNavbar";
 import { Footer } from "@/components/shared/Footer";
 
+// Ensure this layout is always rendered dynamically so that
+// server-only features like `cookies()` work even when building
+// error pages such as `/404`.
+export const dynamic = "force-dynamic";
+
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {

--- a/dashboard/app/not-found.tsx
+++ b/dashboard/app/not-found.tsx
@@ -1,0 +1,5 @@
+export default function NotFound() {
+  return (
+    <div className="flex h-[calc(100vh-4rem)] items-center justify-center">Page Not Found</div>
+  );
+}


### PR DESCRIPTION
## Summary
- mark root `layout.tsx` as `dynamic` so server-only helpers like `cookies()` work
- add custom `not-found` page
- add `error.tsx` page for 500 errors

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6883472a21108320a8d0650d1043b441