### PR TITLE
Add API hooks

### DIFF
--- a/dashboard/app/hooks/useClaims.ts
+++ b/dashboard/app/hooks/useClaims.ts
@@ -1,0 +1,76 @@
+import {
+  useClaimControllerFindAll,
+  useClaimControllerFindOne,
+  useClaimControllerCreate,
+  useClaimControllerUpdate,
+  useClaimControllerRemove,
+  useClaimControllerUpdateClaimStatus,
+  useClaimControllerRemoveFile,
+  type ClaimControllerFindAllParams,
+  type CreateClaimDto,
+  type UpdateClaimDto,
+} from "@/app/api";
+import { parseError } from "../utils/parseError";
+
+export function useClaimsQuery(params?: ClaimControllerFindAllParams) {
+  const query = useClaimControllerFindAll(params);
+  return {
+    ...query,
+    error: parseError(query.error),
+  };
+}
+
+export function useClaimQuery(id: string) {
+  const query = useClaimControllerFindOne(id);
+  return {
+    ...query,
+    error: parseError(query.error),
+  };
+}
+
+export function useCreateClaimMutation() {
+  const mutation = useClaimControllerCreate();
+  return {
+    ...mutation,
+    createClaim: (data: CreateClaimDto) => mutation.mutateAsync({ data }),
+    error: parseError(mutation.error),
+  };
+}
+
+export function useUpdateClaimMutation() {
+  const mutation = useClaimControllerUpdate();
+  return {
+    ...mutation,
+    updateClaim: (id: string, data: UpdateClaimDto) =>
+      mutation.mutateAsync({ id, data }),
+    error: parseError(mutation.error),
+  };
+}
+
+export function useRemoveClaimMutation() {
+  const mutation = useClaimControllerRemove();
+  return {
+    ...mutation,
+    removeClaim: (id: string) => mutation.mutateAsync({ id }),
+    error: parseError(mutation.error),
+  };
+}
+
+export function useUpdateClaimStatusMutation() {
+  const mutation = useClaimControllerUpdateClaimStatus();
+  return {
+    ...mutation,
+    updateClaimStatus: (id: string, status: string) =>
+      mutation.mutateAsync({ id, status }),
+    error: parseError(mutation.error),
+  };
+}
+
+export function useRemoveClaimFileMutation() {
+  const mutation = useClaimControllerRemoveFile();
+  return {
+    ...mutation,
+    removeClaimFile: (id: string) => mutation.mutateAsync({ id }),
+    error: parseError(mutation.error),
+  };
+}

--- a/dashboard/app/hooks/useCoverage.ts
+++ b/dashboard/app/hooks/useCoverage.ts
@@ -1,0 +1,64 @@
+import {
+  useCoverageControllerFindAll,
+  useCoverageControllerFindOne,
+  useCoverageControllerCreate,
+  useCoverageControllerUpdate,
+  useCoverageControllerRemove,
+  useCoverageControllerGetPolicyholderSummary,
+  type CoverageControllerFindAllParams,
+  type CreateCoverageDto,
+  type UpdateCoverageDto,
+} from "@/app/api";
+import { parseError } from "../utils/parseError";
+
+export function useCoverageListQuery(params?: CoverageControllerFindAllParams) {
+  const query = useCoverageControllerFindAll(params);
+  return {
+    ...query,
+    error: parseError(query.error),
+  };
+}
+
+export function useCoverageQuery(id: string) {
+  const query = useCoverageControllerFindOne(id);
+  return {
+    ...query,
+    error: parseError(query.error),
+  };
+}
+
+export function useCreateCoverageMutation() {
+  const mutation = useCoverageControllerCreate();
+  return {
+    ...mutation,
+    createCoverage: (data: CreateCoverageDto) => mutation.mutateAsync({ data }),
+    error: parseError(mutation.error),
+  };
+}
+
+export function useUpdateCoverageMutation() {
+  const mutation = useCoverageControllerUpdate();
+  return {
+    ...mutation,
+    updateCoverage: (id: string, data: UpdateCoverageDto) =>
+      mutation.mutateAsync({ id, data }),
+    error: parseError(mutation.error),
+  };
+}
+
+export function useRemoveCoverageMutation() {
+  const mutation = useCoverageControllerRemove();
+  return {
+    ...mutation,
+    removeCoverage: (id: string) => mutation.mutateAsync({ id }),
+    error: parseError(mutation.error),
+  };
+}
+
+export function usePolicyholderSummaryQuery(id: string) {
+  const query = useCoverageControllerGetPolicyholderSummary(id);
+  return {
+    ...query,
+    error: parseError(query.error),
+  };
+}

--- a/dashboard/app/hooks/usePdfClaimExtractor.ts
+++ b/dashboard/app/hooks/usePdfClaimExtractor.ts
@@ -1,0 +1,14 @@
+import {
+  usePdfClaimExtractorControllerExtract,
+  type ExtractClaimDto,
+} from "@/app/api";
+import { parseError } from "../utils/parseError";
+
+export function useExtractClaimMutation() {
+  const mutation = usePdfClaimExtractorControllerExtract();
+  return {
+    ...mutation,
+    extractClaim: (data: ExtractClaimDto) => mutation.mutateAsync({ data }),
+    error: parseError(mutation.error),
+  };
+}

--- a/dashboard/app/hooks/usePolicies.ts
+++ b/dashboard/app/hooks/usePolicies.ts
@@ -1,0 +1,75 @@
+import {
+  usePolicyControllerFindAll,
+  usePolicyControllerFindOne,
+  usePolicyControllerCreate,
+  usePolicyControllerUpdate,
+  usePolicyControllerRemove,
+  usePolicyControllerGetSummary,
+  usePolicyControllerGetCategoryCounts,
+  type PolicyControllerFindAllParams,
+  type CreatePolicyDto,
+  type UpdatePolicyDto,
+} from "@/app/api";
+import { parseError } from "../utils/parseError";
+
+export function usePoliciesQuery(params?: PolicyControllerFindAllParams) {
+  const query = usePolicyControllerFindAll(params);
+  return {
+    ...query,
+    error: parseError(query.error),
+  };
+}
+
+export function usePolicyQuery(id: string) {
+  const query = usePolicyControllerFindOne(id);
+  return {
+    ...query,
+    error: parseError(query.error),
+  };
+}
+
+export function useCreatePolicyMutation() {
+  const mutation = usePolicyControllerCreate();
+  return {
+    ...mutation,
+    createPolicy: (data: CreatePolicyDto) => mutation.mutateAsync({ data }),
+    error: parseError(mutation.error),
+  };
+}
+
+export function useUpdatePolicyMutation() {
+  const mutation = usePolicyControllerUpdate();
+  return {
+    ...mutation,
+    updatePolicy: (id: string, data: UpdatePolicyDto) =>
+      mutation.mutateAsync({ id, data }),
+    error: parseError(mutation.error),
+  };
+}
+
+export function useRemovePolicyMutation() {
+  const mutation = usePolicyControllerRemove();
+  return {
+    ...mutation,
+    removePolicy: (id: string) => mutation.mutateAsync({ id }),
+    error: parseError(mutation.error),
+  };
+}
+
+export function usePolicySummaryQuery(id: string) {
+  const query = usePolicyControllerGetSummary(id);
+  return {
+    ...query,
+    error: parseError(query.error),
+  };
+}
+
+export function useCategoryCountsQuery(params: {
+  category?: string;
+}) {
+  const query = usePolicyControllerGetCategoryCounts(params);
+  return {
+    ...query,
+    error: parseError(query.error),
+  };
+}

--- a/dashboard/app/hooks/useReviews.ts
+++ b/dashboard/app/hooks/useReviews.ts
@@ -1,0 +1,15 @@
+import {
+  useReviewsControllerLeaveReview,
+  type CreateReviewDto,
+} from "@/app/api";
+import { parseError } from "../utils/parseError";
+
+export function useLeaveReviewMutation() {
+  const mutation = useReviewsControllerLeaveReview();
+  return {
+    ...mutation,
+    leaveReview: (id: string, data: CreateReviewDto) =>
+      mutation.mutateAsync({ id, data }),
+    error: parseError(mutation.error),
+  };
+}

--- a/dashboard/app/hooks/useUsers.ts
+++ b/dashboard/app/hooks/useUsers.ts
@@ -1,0 +1,53 @@
+import {
+  useUserControllerFindAll,
+  useUserControllerFindOne,
+  useUserControllerCreate,
+  useUserControllerUpdate,
+  useUserControllerGetStats,
+  type CreateUserDto,
+  type UpdateUserDto,
+} from "@/app/api";
+import { parseError } from "../utils/parseError";
+
+export function useUsersQuery() {
+  const query = useUserControllerFindAll();
+  return {
+    ...query,
+    error: parseError(query.error),
+  };
+}
+
+export function useUserQuery(id: string) {
+  const query = useUserControllerFindOne(id);
+  return {
+    ...query,
+    error: parseError(query.error),
+  };
+}
+
+export function useCreateUserMutation() {
+  const mutation = useUserControllerCreate();
+  return {
+    ...mutation,
+    createUser: (data: CreateUserDto) => mutation.mutateAsync({ data }),
+    error: parseError(mutation.error),
+  };
+}
+
+export function useUpdateUserMutation() {
+  const mutation = useUserControllerUpdate();
+  return {
+    ...mutation,
+    updateUser: (id: string, data: UpdateUserDto) =>
+      mutation.mutateAsync({ id, data }),
+    error: parseError(mutation.error),
+  };
+}
+
+export function useUserStatsQuery() {
+  const query = useUserControllerGetStats();
+  return {
+    ...query,
+    error: parseError(query.error),
+  };
+}


### PR DESCRIPTION
## Summary
- add hooks for users
- add hooks for policies
- add hooks for claims
- add hooks for coverage
- add hook for pdf claim extraction
- add hook for reviews

## Testing
- `npm --prefix dashboard run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883ac2c7e108320a5b3dadd819a6eb1