### PR TITLE
Add toast provider with theme support

### DIFF
--- a/dashboard/app/(auth)/auth/login/page.tsx
+++ b/dashboard/app/(auth)/auth/login/page.tsx
@@ -8,11 +8,13 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Shield, Eye, EyeOff, ArrowLeft, Zap, Globe } from "lucide-react";
 import Link from "next/link";
 import useAuth from "@/app/hooks/useAuth";
+import { useToast } from "@/components/shared/ToastProvider";
 import { useRouter } from "next/navigation";
 import GetStartedButton from '@/components/animata/button/get-started-button';
 export default function LoginPage() {
   const router = useRouter();
   const { login, isLoggingIn, loginError } = useAuth();
+  const { showToast } = useToast();
   const [showPassword, setShowPassword] = useState(false);
   const [formData, setFormData] = useState({
     email: "",
@@ -24,10 +26,12 @@ export default function LoginPage() {
     e.preventDefault();
     try {
       await login({ email: formData.email, password: formData.password });
+      showToast('Logged in successfully', 'success');
       router.push("/");
       router.refresh();
     } catch (err) {
       console.error(err);
+      showToast(loginError || 'Login failed', 'error');
     }
   };
 
@@ -212,11 +216,6 @@ export default function LoginPage() {
                   </div>
 
                   <GetStartedButton text="Sign In" loading={isLoggingIn} />
-                  {loginError && (
-                    <p className="text-red-500 text-sm mt-2 text-center">
-                      {loginError || "Login failed"}
-                    </p>
-                  )}
                 </form>
 
                 <div className="mt-6 text-center">

--- a/dashboard/app/(auth)/auth/register/page.tsx
+++ b/dashboard/app/(auth)/auth/register/page.tsx
@@ -28,6 +28,7 @@ import {
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import useAuth from "@/app/hooks/useAuth";
+import { useToast } from "@/components/shared/ToastProvider";
 
 export default function RegisterPage() {
   const searchParams = useSearchParams();
@@ -39,6 +40,7 @@ export default function RegisterPage() {
   const [currentStep, setCurrentStep] = useState(1);
   const router = useRouter();
   const { register: registerUser, isRegistering, registerError } = useAuth();
+  const { showToast } = useToast();
 
   const [formData, setFormData] = useState({
     // Basic Info
@@ -99,9 +101,11 @@ export default function RegisterPage() {
             occupation: formData.occupation,
             address: formData.address,
           });
+          showToast('Account created successfully', 'success');
           router.push("/auth/login");
         } catch (err) {
           console.error(err);
+          showToast(registerError || 'Registration failed', 'error');
         }
       }
     }
@@ -707,11 +711,6 @@ export default function RegisterPage() {
                       )}
                     </Button>
                   </div>
-                  {registerError && (
-                    <p className="text-red-500 text-sm mt-2 text-center">
-                      {registerError || "Login failed"}
-                    </p>
-                  )}
                 </form>
               </CardContent>
             </Card>

--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "@/components/shared/ThemeProvider";
 import { Footer } from "@/components/shared/Footer";
 import Web3Providers from './providers/Web3Providers';
 import GlobalNavbar from '@/components/shared/GlobalNavbar';
+import { ToastProvider } from '@/components/shared/ToastProvider';
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -24,9 +25,11 @@ export default function RootLayout({
       <body className={inter.className} suppressHydrationWarning>
         <Web3Providers>
           <ThemeProvider defaultTheme="light" storageKey="blocksecure-ui-theme">
-            <GlobalNavbar />
-            <main className="pt-16">{children}</main>
-            <Footer />
+            <ToastProvider>
+              <GlobalNavbar />
+              <main className="pt-16">{children}</main>
+              <Footer />
+            </ToastProvider>
           </ThemeProvider>
         </Web3Providers>
       </body>

--- a/dashboard/components/shared/ToastProvider.tsx
+++ b/dashboard/components/shared/ToastProvider.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import React, { createContext, useContext, useState, useCallback } from 'react';
+import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export type ToastType = 'success' | 'error' | 'info';
+
+interface Toast {
+  id: string;
+  message: string;
+  type: ToastType;
+}
+
+interface ToastContextState {
+  showToast: (message: string, type?: ToastType) => void;
+}
+
+const ToastContext = createContext<ToastContextState | undefined>(undefined);
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const showToast = useCallback((message: string, type: ToastType = 'info') => {
+    const id = Math.random().toString(36).substring(2, 9);
+    setToasts((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => removeToast(id), 3000);
+  }, [removeToast]);
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <div className="fixed top-4 right-4 z-50 space-y-2">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={cn(
+              'glass-card border px-4 py-3 rounded-md shadow-lg flex items-start justify-between animate-fade-in',
+              toast.type === 'success' && 'border-emerald-500 text-emerald-700 dark:text-emerald-400',
+              toast.type === 'error' && 'border-red-500 text-red-700 dark:text-red-400',
+              toast.type === 'info' && 'border-slate-200 dark:border-slate-700'
+            )}
+          >
+            <span className="pr-2">{toast.message}</span>
+            <button onClick={() => removeToast(toast.id)} aria-label="Close" className="mt-0.5">
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- implement custom `ToastProvider` for showing notifications
- hook up toast provider in app layout
- use toast notifications for login and registration forms

## Testing
- `npm --prefix dashboard run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887598c1e7083209b1bef618d80ab63