### PR TITLE
Update hooks for new document upload APIs

### DIFF
--- a/dashboard/app/hooks/useClaims.ts
+++ b/dashboard/app/hooks/useClaims.ts
@@ -6,6 +6,8 @@ import {
   useClaimControllerRemove,
   useClaimControllerUpdateClaimStatus,
   useClaimControllerRemoveFile,
+  useClaimControllerUploadDocuments,
+  type UploadDocDto,
   type ClaimControllerFindAllParams,
   type CreateClaimDto,
   type UpdateClaimDto,
@@ -72,6 +74,16 @@ export function useRemoveClaimFileMutation() {
   return {
     ...mutation,
     removeClaimFile: (id: string) => mutation.mutateAsync({ id }),
+    error: parseError(mutation.error),
+  };
+}
+
+export function useUploadClaimDocumentsMutation() {
+  const mutation = useClaimControllerUploadDocuments();
+  return {
+    ...mutation,
+    uploadClaimDocuments: (id: string, data: UploadDocDto) =>
+      mutation.mutateAsync({ id, data }),
     error: parseError(mutation.error),
   };
 }

--- a/dashboard/app/hooks/useCompany.ts
+++ b/dashboard/app/hooks/useCompany.ts
@@ -1,0 +1,12 @@
+import { useCompanyControllerUpload, type UploadDocDto } from "@/app/api";
+import { parseError } from "../utils/parseError";
+
+export function useCompanyUploadMutation() {
+  const mutation = useCompanyControllerUpload();
+  return {
+    ...mutation,
+    uploadCompanyDocuments: (id: string, data: UploadDocDto) =>
+      mutation.mutateAsync({ id, data }),
+    error: parseError(mutation.error),
+  };
+}

--- a/dashboard/app/hooks/usePolicies.ts
+++ b/dashboard/app/hooks/usePolicies.ts
@@ -6,6 +6,8 @@ import {
   usePolicyControllerRemove,
   usePolicyControllerGetSummary,
   usePolicyControllerGetCategoryCounts,
+  usePolicyControllerUploadDocuments,
+  type UploadDocDto,
   type PolicyControllerFindAllParams,
   type CreatePolicyDto,
   type UpdatePolicyDto,
@@ -69,5 +71,15 @@ export function useCategoryCountsQuery() {
   return {
     ...query,
     error: parseError(query.error),
+  };
+}
+
+export function useUploadPolicyDocumentsMutation() {
+  const mutation = usePolicyControllerUploadDocuments();
+  return {
+    ...mutation,
+    uploadPolicyDocuments: (id: string, data: UploadDocDto) =>
+      mutation.mutateAsync({ id, data }),
+    error: parseError(mutation.error),
   };
 }


### PR DESCRIPTION
## Summary
- add new upload document mutations for claims, policies, and company
- expose new hook in hooks folder

## Testing
- `npm test --workspaces` *(fails: jest not found, npm 403)*

------
https://chatgpt.com/codex/tasks/task_e_6887bb9750b48320b64605203ce2ad88