### PR TITLE
Return company ID after provider registration

### DIFF
--- a/backend/src/api/auth/auth.service.ts
+++ b/backend/src/api/auth/auth.service.ts
@@ -13,7 +13,7 @@ import { AuthUserResponseDto } from './dto/responses/auth-user.dto';
 import { parseAppMetadata, parseUserMetadata } from 'src/utils/auth-metadata';
 import { Response } from 'express';
 import { UserService } from '../user/user.service';
-import { UserRole, AdminDetails } from 'src/enums';
+import { UserRole } from 'src/enums';
 
 @Injectable()
 export class AuthService {
@@ -100,21 +100,17 @@ export class AuthService {
       }
 
       await this.userService.createUserProfile(supabase, user_id, dto);
-      const roleDetails = await this.userService.createRoleSpecificDetails(
-        supabase,
-        user_id,
-        dto,
-      );
-
-      let companyId: number | null = null;
-      if (dto.role === UserRole.INSURANCE_ADMIN && roleDetails) {
-        companyId = (roleDetails as AdminDetails).company_id ?? null;
+      if (dto.role !== UserRole.INSURANCE_ADMIN) {
+        await this.userService.createRoleSpecificDetails(
+          supabase,
+          user_id,
+          dto,
+        );
       }
 
       return new CommonResponseDto({
         statusCode: 201,
         message: 'Registration successful',
-        data: companyId ? { companyId } : undefined,
       });
     } catch (e) {
       return new CommonResponseDto({

--- a/backend/src/api/auth/dto/requests/register.dto.ts
+++ b/backend/src/api/auth/dto/requests/register.dto.ts
@@ -1,5 +1,4 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
 import {
   IsEmail,
   IsNotEmpty,
@@ -9,60 +8,10 @@ import {
   MinLength,
   Matches,
   ValidateIf,
-  IsUrl,
-  ValidateNested,
   IsEnum,
 } from 'class-validator';
 import { ToPhone } from 'src/common/to-phone';
-import { NumberOfEmployees, UserRole, YearsInBusiness } from 'src/enums';
-
-export class CompanyDetailsDto {
-  @ApiProperty({ example: 'ABC Company', required: false })
-  @IsNotEmpty()
-  @IsString()
-  name!: string;
-
-  @ApiProperty({ example: '123 Main St, New York, USA', required: false })
-  @IsNotEmpty()
-  @IsString()
-  address!: string;
-
-  @ApiProperty({ example: '+1 555-1234', required: false })
-  @IsOptional()
-  @IsString()
-  contact_no?: string;
-
-  @ApiProperty({ example: 'www.abccompany.com', required: false })
-  @IsOptional()
-  @IsUrl()
-  website?: string;
-
-  @ApiProperty({ example: 'LIC-00012345', required: false })
-  @IsNotEmpty()
-  @IsString()
-  license_number!: string;
-
-  @ApiProperty({
-    example: YearsInBusiness.ZERO_TO_ONE,
-    enum: YearsInBusiness,
-  })
-  @IsNotEmpty()
-  @IsEnum(YearsInBusiness)
-  years_in_business!: YearsInBusiness;
-
-  @ApiProperty({
-    example: NumberOfEmployees.ZERO_TO_TEN,
-    enum: NumberOfEmployees,
-  })
-  @IsNotEmpty()
-  @IsEnum(NumberOfEmployees)
-  employees_number!: NumberOfEmployees;
-
-  @ApiProperty({ example: '2024-01-01T00:00:00Z', required: false })
-  @IsOptional()
-  @IsString()
-  created_at?: string;
-}
+import { UserRole } from 'src/enums';
 
 export class RegisterDto {
   // 🔐 Credentials
@@ -125,13 +74,6 @@ export class RegisterDto {
   @IsOptional()
   @IsString()
   bio?: string;
-
-  //Admin-only details
-  @ValidateIf((o: RegisterDto) => o.role === UserRole.INSURANCE_ADMIN)
-  @ApiProperty({ type: () => CompanyDetailsDto, required: false })
-  @ValidateNested()
-  @Type(() => CompanyDetailsDto)
-  company?: CompanyDetailsDto;
 
   //Policyholder-only details
   @ValidateIf((o: RegisterDto) => o.role === UserRole.POLICYHOLDER)

--- a/backend/src/api/company/company.controller.ts
+++ b/backend/src/api/company/company.controller.ts
@@ -21,8 +21,13 @@ export class CompanyController {
   constructor(private readonly service: CompanyService) {}
 
   @Post()
-  create(@Body() dto: CompanyDetailsDto): Promise<CommonResponseDto> {
-    return this.service.createCompany(dto);
+  @ApiConsumes('multipart/form-data')
+  @UseInterceptors(FilesInterceptor('files'))
+  create(
+    @Body() dto: CompanyDetailsDto,
+    @UploadedFiles() files: Array<Express.Multer.File>,
+  ): Promise<CommonResponseDto> {
+    return this.service.createCompany(dto, files);
   }
 
   @Post(':id/documents')

--- a/backend/src/api/company/company.controller.ts
+++ b/backend/src/api/company/company.controller.ts
@@ -13,11 +13,17 @@ import { AuthenticatedRequest } from 'src/supabase/types/express';
 import { CompanyService } from './company.service';
 import { CommonResponseDto } from 'src/common/common.dto';
 import { UploadDocDto } from '../file/requests/document-upload.dto';
+import { CompanyDetailsDto } from '../auth/dto/requests/register.dto';
 
 @Controller('company')
 @ApiBearerAuth('supabase-auth')
 export class CompanyController {
   constructor(private readonly service: CompanyService) {}
+
+  @Post()
+  create(@Body() dto: CompanyDetailsDto): Promise<CommonResponseDto> {
+    return this.service.createCompany(dto);
+  }
 
   @Post(':id/documents')
   @ApiConsumes('multipart/form-data')

--- a/backend/src/api/company/company.controller.ts
+++ b/backend/src/api/company/company.controller.ts
@@ -13,7 +13,7 @@ import { AuthenticatedRequest } from 'src/supabase/types/express';
 import { CompanyService } from './company.service';
 import { CommonResponseDto } from 'src/common/common.dto';
 import { UploadDocDto } from '../file/requests/document-upload.dto';
-import { CompanyDetailsDto } from '../auth/dto/requests/register.dto';
+import { CompanyDetailsDto } from './dto/create-company.dto';
 
 @Controller('company')
 @ApiBearerAuth('supabase-auth')

--- a/backend/src/api/company/company.service.ts
+++ b/backend/src/api/company/company.service.ts
@@ -2,6 +2,7 @@ import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { FileService } from '../file/file.service';
 import { CommonResponseDto } from 'src/common/common.dto';
 import { SupabaseService } from 'src/supabase/supabase.service';
+import { CompanyDetailsDto } from '../auth/dto/requests/register.dto';
 
 @Injectable()
 export class CompanyService {
@@ -9,6 +10,26 @@ export class CompanyService {
     private readonly fileService: FileService,
     private readonly supabaseService: SupabaseService,
   ) {}
+
+  async createCompany(dto: CompanyDetailsDto): Promise<CommonResponseDto> {
+    const supabase = this.supabaseService.createClientWithToken();
+
+    const { data, error } = await supabase
+      .from('companies')
+      .insert([dto])
+      .select('id')
+      .single();
+
+    if (error || !data?.id) {
+      throw new InternalServerErrorException('Failed to create company');
+    }
+
+    return new CommonResponseDto({
+      statusCode: 201,
+      message: 'Company created successfully',
+      data: { id: data.id },
+    });
+  }
 
   async addDocuments(
     companyId: number,

--- a/backend/src/api/company/company.service.ts
+++ b/backend/src/api/company/company.service.ts
@@ -11,7 +11,10 @@ export class CompanyService {
     private readonly supabaseService: SupabaseService,
   ) {}
 
-  async createCompany(dto: CompanyDetailsDto): Promise<CommonResponseDto> {
+  async createCompany(
+    dto: CompanyDetailsDto,
+    files: Array<Express.Multer.File> = [],
+  ): Promise<CommonResponseDto> {
     const supabase = this.supabaseService.createClientWithToken();
 
     const { data, error } = await supabase
@@ -22,6 +25,10 @@ export class CompanyService {
 
     if (error || !data?.id) {
       throw new InternalServerErrorException('Failed to create company');
+    }
+
+    if (files.length) {
+      await this.addDocuments(data.id, files);
     }
 
     return new CommonResponseDto({

--- a/backend/src/api/company/company.service.ts
+++ b/backend/src/api/company/company.service.ts
@@ -2,7 +2,7 @@ import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { FileService } from '../file/file.service';
 import { CommonResponseDto } from 'src/common/common.dto';
 import { SupabaseService } from 'src/supabase/supabase.service';
-import { CompanyDetailsDto } from '../auth/dto/requests/register.dto';
+import { CompanyDetailsDto } from './dto/create-company.dto';
 
 @Injectable()
 export class CompanyService {

--- a/backend/src/api/company/dto/create-company.dto.ts
+++ b/backend/src/api/company/dto/create-company.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsString,
+  IsOptional,
+  IsUrl,
+  IsEnum,
+} from 'class-validator';
+import { YearsInBusiness, NumberOfEmployees } from 'src/enums';
+
+export class CompanyDetailsDto {
+  @ApiProperty({ example: 'ABC Company', required: false })
+  @IsNotEmpty()
+  @IsString()
+  name!: string;
+
+  @ApiProperty({ example: '123 Main St, New York, USA', required: false })
+  @IsNotEmpty()
+  @IsString()
+  address!: string;
+
+  @ApiProperty({ example: '+1 555-1234', required: false })
+  @IsOptional()
+  @IsString()
+  contact_no?: string;
+
+  @ApiProperty({ example: 'www.abccompany.com', required: false })
+  @IsOptional()
+  @IsUrl()
+  website?: string;
+
+  @ApiProperty({ example: 'LIC-00012345', required: false })
+  @IsNotEmpty()
+  @IsString()
+  license_number!: string;
+
+  @ApiProperty({
+    example: YearsInBusiness.ZERO_TO_ONE,
+    enum: YearsInBusiness,
+  })
+  @IsNotEmpty()
+  @IsEnum(YearsInBusiness)
+  years_in_business!: YearsInBusiness;
+
+  @ApiProperty({
+    example: NumberOfEmployees.ZERO_TO_TEN,
+    enum: NumberOfEmployees,
+  })
+  @IsNotEmpty()
+  @IsEnum(NumberOfEmployees)
+  employees_number!: NumberOfEmployees;
+
+  @ApiProperty({ example: '2024-01-01T00:00:00Z', required: false })
+  @IsOptional()
+  @IsString()
+  created_at?: string;
+}

--- a/backend/src/api/user/dto/requests/create.dto.ts
+++ b/backend/src/api/user/dto/requests/create.dto.ts
@@ -11,7 +11,7 @@ import {
   ValidateIf,
   ValidateNested,
 } from 'class-validator';
-import { CompanyDetailsDto } from 'src/api/auth/dto/requests/register.dto';
+import { CompanyDetailsDto } from 'src/api/company/dto/create-company.dto';
 import { ToPhone } from 'src/common/to-phone';
 import { UserRole } from 'src/enums';
 

--- a/backend/src/api/user/user.service.ts
+++ b/backend/src/api/user/user.service.ts
@@ -14,7 +14,7 @@ import {
   AdminDetails,
   PolicyholderDetails,
 } from 'src/enums';
-import { CompanyDetailsDto } from '../auth/dto/requests/register.dto';
+import { CompanyDetailsDto } from '../company/dto/create-company.dto';
 
 @Injectable()
 export class UserService {

--- a/backend/swagger-spec.json
+++ b/backend/swagger-spec.json
@@ -1476,6 +1476,35 @@
         ]
       }
     },
+    "/company": {
+      "post": {
+        "operationId": "CompanyController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/CompanyDetailsDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "supabase-auth": []
+          }
+        ],
+        "tags": [
+          "Company"
+        ]
+      }
+    },
     "/company/{id}/documents": {
       "post": {
         "operationId": "CompanyController_upload",
@@ -1652,61 +1681,6 @@
           "password"
         ]
       },
-      "CompanyDetailsDto": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "example": "ABC Company"
-          },
-          "address": {
-            "type": "string",
-            "example": "123 Main St, New York, USA"
-          },
-          "contact_no": {
-            "type": "string",
-            "example": "+1 555-1234"
-          },
-          "website": {
-            "type": "string",
-            "example": "www.abccompany.com"
-          },
-          "license_number": {
-            "type": "string",
-            "example": "LIC-00012345"
-          },
-          "years_in_business": {
-            "type": "string",
-            "example": "0-1 years",
-            "enum": [
-              "0-1 years",
-              "2-5 years",
-              "6-10 years",
-              "11-20 years",
-              "20+ years"
-            ]
-          },
-          "employees_number": {
-            "type": "string",
-            "example": "1-10 employees",
-            "enum": [
-              "1-10 employees",
-              "11-50 employees",
-              "51-200 employees",
-              "201-500 employees",
-              "500+ employees"
-            ]
-          },
-          "created_at": {
-            "type": "string",
-            "example": "2024-01-01T00:00:00Z"
-          }
-        },
-        "required": [
-          "years_in_business",
-          "employees_number"
-        ]
-      },
       "RegisterDto": {
         "type": "object",
         "properties": {
@@ -1749,9 +1723,6 @@
           "bio": {
             "type": "string",
             "example": "I am a policyholder"
-          },
-          "company": {
-            "$ref": "#/components/schemas/CompanyDetailsDto"
           },
           "dateOfBirth": {
             "type": "string",
@@ -1844,6 +1815,61 @@
           "activeUsers",
           "policyholders",
           "insuranceAdmins"
+        ]
+      },
+      "CompanyDetailsDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "ABC Company"
+          },
+          "address": {
+            "type": "string",
+            "example": "123 Main St, New York, USA"
+          },
+          "contact_no": {
+            "type": "string",
+            "example": "+1 555-1234"
+          },
+          "website": {
+            "type": "string",
+            "example": "www.abccompany.com"
+          },
+          "license_number": {
+            "type": "string",
+            "example": "LIC-00012345"
+          },
+          "years_in_business": {
+            "type": "string",
+            "example": "0-1 years",
+            "enum": [
+              "0-1 years",
+              "2-5 years",
+              "6-10 years",
+              "11-20 years",
+              "20+ years"
+            ]
+          },
+          "employees_number": {
+            "type": "string",
+            "example": "1-10 employees",
+            "enum": [
+              "1-10 employees",
+              "11-50 employees",
+              "51-200 employees",
+              "201-500 employees",
+              "500+ employees"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "example": "2024-01-01T00:00:00Z"
+          }
+        },
+        "required": [
+          "years_in_business",
+          "employees_number"
         ]
       },
       "CreateUserDto": {

--- a/dashboard/app/(auth)/auth/register/provider/page.tsx
+++ b/dashboard/app/(auth)/auth/register/provider/page.tsx
@@ -243,7 +243,7 @@ export default function ProviderRegistrationPage() {
       setCurrentStep(currentStep + 1);
     } else {
       try {
-        await registerAdmin({
+        const res = await registerAdmin({
           email: adminInfo.email,
           password: adminInfo.password,
           confirmPassword: adminInfo.confirmPassword,
@@ -261,12 +261,13 @@ export default function ProviderRegistrationPage() {
             employees_number: formData.employeeCount as CompanyDetailsDtoEmployeesNumber,
           },
         });
+        const companyId = (res as any)?.data?.companyId ?? "";
         const companyDocs = Object.values(uploadedFiles)
           .flat()
           .map((f) => f.file);
         if (companyDocs.length) {
           try {
-            await uploadCompanyDocuments("1", { files: companyDocs });
+            await uploadCompanyDocuments(String(companyId), { files: companyDocs });
           } catch (uploadErr) {
             console.error(uploadErr);
           }

--- a/dashboard/app/(auth)/auth/register/provider/page.tsx
+++ b/dashboard/app/(auth)/auth/register/provider/page.tsx
@@ -34,7 +34,10 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import useAuth from "@/app/hooks/useAuth";
-import { useCompanyUploadMutation } from "@/app/hooks/useCompany";
+import {
+  useCompanyUploadMutation,
+  useCreateCompanyMutation,
+} from "@/app/hooks/useCompany";
 import { parseError } from "@/app/utils/parseError";
 import { useToast } from "@/components/shared/ToastProvider";
 import { useRouter } from "next/navigation";
@@ -63,6 +66,7 @@ export default function ProviderRegistrationPage() {
   const { printMessage } = useToast();
   const router = useRouter();
   const { uploadCompanyDocuments } = useCompanyUploadMutation();
+  const { createCompany } = useCreateCompanyMutation();
 
   const [formData, setFormData] = useState({
     // Personal & Account Info (collected separately)
@@ -243,7 +247,7 @@ export default function ProviderRegistrationPage() {
       setCurrentStep(currentStep + 1);
     } else {
       try {
-        const res = await registerAdmin({
+        await registerAdmin({
           email: adminInfo.email,
           password: adminInfo.password,
           confirmPassword: adminInfo.confirmPassword,
@@ -251,17 +255,19 @@ export default function ProviderRegistrationPage() {
           lastName: adminInfo.lastName,
           role: RegisterDtoRole.insurance_admin,
           phone: adminInfo.phone,
-          company: {
-            name: formData.companyName,
-            address: formData.businessAddress,
-            license_number: formData.licenseNumber,
-            contact_no: formData.businessPhone,
-            website: formData.website,
-            years_in_business: formData.yearsInBusiness as CompanyDetailsDtoYearsInBusiness,
-            employees_number: formData.employeeCount as CompanyDetailsDtoEmployeesNumber,
-          },
         });
-        const companyId = (res as any)?.data?.companyId ?? "";
+        const companyRes = await createCompany({
+          name: formData.companyName,
+          address: formData.businessAddress,
+          license_number: formData.licenseNumber,
+          contact_no: formData.businessPhone,
+          website: formData.website,
+          years_in_business:
+            formData.yearsInBusiness as CompanyDetailsDtoYearsInBusiness,
+          employees_number:
+            formData.employeeCount as CompanyDetailsDtoEmployeesNumber,
+        });
+        const companyId = (companyRes as any)?.data?.id ?? "";
         const companyDocs = Object.values(uploadedFiles)
           .flat()
           .map((f) => f.file);

--- a/dashboard/app/(auth)/auth/register/provider/page.tsx
+++ b/dashboard/app/(auth)/auth/register/provider/page.tsx
@@ -34,14 +34,11 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import useAuth from "@/app/hooks/useAuth";
-import {
-  useCompanyUploadMutation,
-  useCreateCompanyMutation,
-} from "@/app/hooks/useCompany";
+import { useCreateCompanyMutation } from "@/app/hooks/useCompany";
 import { parseError } from "@/app/utils/parseError";
 import { useToast } from "@/components/shared/ToastProvider";
 import { useRouter } from "next/navigation";
-import { CompanyDetailsDtoEmployeesNumber, CompanyDetailsDtoYearsInBusiness, RegisterDtoRole } from "@/app/api";
+import { RegisterDtoRole } from "@/app/api";
 import { useAdminRegistrationStore } from "@/app/store/useAdminRegistrationStore";
 
 interface UploadedFile {
@@ -65,7 +62,6 @@ export default function ProviderRegistrationPage() {
   const [dragActive, setDragActive] = useState<string | null>(null);
   const { printMessage } = useToast();
   const router = useRouter();
-  const { uploadCompanyDocuments } = useCompanyUploadMutation();
   const { createCompany } = useCreateCompanyMutation();
 
   const [formData, setFormData] = useState({
@@ -256,28 +252,21 @@ export default function ProviderRegistrationPage() {
           role: RegisterDtoRole.insurance_admin,
           phone: adminInfo.phone,
         });
-        const companyRes = await createCompany({
-          name: formData.companyName,
-          address: formData.businessAddress,
-          license_number: formData.licenseNumber,
-          contact_no: formData.businessPhone,
-          website: formData.website,
-          years_in_business:
-            formData.yearsInBusiness as CompanyDetailsDtoYearsInBusiness,
-          employees_number:
-            formData.employeeCount as CompanyDetailsDtoEmployeesNumber,
-        });
-        const companyId = (companyRes as any)?.data?.id ?? "";
         const companyDocs = Object.values(uploadedFiles)
           .flat()
           .map((f) => f.file);
-        if (companyDocs.length) {
-          try {
-            await uploadCompanyDocuments(String(companyId), { files: companyDocs });
-          } catch (uploadErr) {
-            console.error(uploadErr);
-          }
-        }
+
+        const companyForm = new FormData();
+        companyForm.append("name", formData.companyName);
+        companyForm.append("address", formData.businessAddress);
+        companyForm.append("license_number", formData.licenseNumber);
+        companyForm.append("contact_no", formData.businessPhone);
+        companyForm.append("website", formData.website);
+        companyForm.append("years_in_business", formData.yearsInBusiness);
+        companyForm.append("employees_number", formData.employeeCount);
+        companyDocs.forEach((file) => companyForm.append("files", file));
+
+        await createCompany(companyForm);
         printMessage("Account created successfully", "success");
         resetAdminInfo();
         router.push("/auth/login");

--- a/dashboard/app/api/index.ts
+++ b/dashboard/app/api/index.ts
@@ -4305,14 +4305,14 @@ export const useCompanyControllerUpload = <
 };
 
 export const companyControllerCreate = (
-  companyDetailsDto: CompanyDetailsDto,
+  formData: FormData,
   signal?: AbortSignal,
 ) => {
   return customFetcher<CommonResponseDto>({
     url: `/company`,
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    data: companyDetailsDto,
+    headers: { "Content-Type": "multipart/form-data" },
+    data: formData,
     signal,
   });
 };
@@ -4324,13 +4324,13 @@ export const getCompanyControllerCreateMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof companyControllerCreate>>,
     TError,
-    { data: CompanyDetailsDto },
+    { data: FormData },
     TContext
   >;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof companyControllerCreate>>,
   TError,
-  { data: CompanyDetailsDto },
+  { data: FormData },
   TContext
 > => {
   const mutationKey = ["companyControllerCreate"];
@@ -4344,7 +4344,7 @@ export const getCompanyControllerCreateMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof companyControllerCreate>>,
-    { data: CompanyDetailsDto }
+    { data: FormData }
   > = (props) => {
     const { data } = props ?? {};
 
@@ -4357,7 +4357,7 @@ export const getCompanyControllerCreateMutationOptions = <
 export type CompanyControllerCreateMutationResult = NonNullable<
   Awaited<ReturnType<typeof companyControllerCreate>>
 >;
-export type CompanyControllerCreateMutationBody = CompanyDetailsDto;
+export type CompanyControllerCreateMutationBody = FormData;
 export type CompanyControllerCreateMutationError = unknown;
 
 export const useCompanyControllerCreate = <TError = unknown, TContext = unknown>(
@@ -4365,7 +4365,7 @@ export const useCompanyControllerCreate = <TError = unknown, TContext = unknown>
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof companyControllerCreate>>,
       TError,
-      { data: CompanyDetailsDto },
+      { data: FormData },
       TContext
     >;
   },
@@ -4373,7 +4373,7 @@ export const useCompanyControllerCreate = <TError = unknown, TContext = unknown>
 ): UseMutationResult<
   Awaited<ReturnType<typeof companyControllerCreate>>,
   TError,
-  { data: CompanyDetailsDto },
+  { data: FormData },
   TContext
 > => {
   const mutationOptions = getCompanyControllerCreateMutationOptions(options);

--- a/dashboard/app/api/index.ts
+++ b/dashboard/app/api/index.ts
@@ -4303,3 +4303,80 @@ export const useCompanyControllerUpload = <
 
   return useMutation(mutationOptions, queryClient);
 };
+
+export const companyControllerCreate = (
+  companyDetailsDto: CompanyDetailsDto,
+  signal?: AbortSignal,
+) => {
+  return customFetcher<CommonResponseDto>({
+    url: `/company`,
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    data: companyDetailsDto,
+    signal,
+  });
+};
+
+export const getCompanyControllerCreateMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof companyControllerCreate>>,
+    TError,
+    { data: CompanyDetailsDto },
+    TContext
+  >;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof companyControllerCreate>>,
+  TError,
+  { data: CompanyDetailsDto },
+  TContext
+> => {
+  const mutationKey = ["companyControllerCreate"];
+  const { mutation: mutationOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof companyControllerCreate>>,
+    { data: CompanyDetailsDto }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return companyControllerCreate(data);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type CompanyControllerCreateMutationResult = NonNullable<
+  Awaited<ReturnType<typeof companyControllerCreate>>
+>;
+export type CompanyControllerCreateMutationBody = CompanyDetailsDto;
+export type CompanyControllerCreateMutationError = unknown;
+
+export const useCompanyControllerCreate = <TError = unknown, TContext = unknown>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof companyControllerCreate>>,
+      TError,
+      { data: CompanyDetailsDto },
+      TContext
+    >;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof companyControllerCreate>>,
+  TError,
+  { data: CompanyDetailsDto },
+  TContext
+> => {
+  const mutationOptions = getCompanyControllerCreateMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};

--- a/dashboard/app/api/index.ts
+++ b/dashboard/app/api/index.ts
@@ -4218,6 +4218,108 @@ export const useReviewsControllerLeaveReview = <
   return useMutation(mutationOptions, queryClient);
 };
 
+export const companyControllerCreate = (
+  companyDetailsDto: CompanyDetailsDto,
+  signal?: AbortSignal,
+) => {
+  const formData = new FormData();
+  if (companyDetailsDto.name !== undefined) {
+    formData.append(`name`, companyDetailsDto.name);
+  }
+  if (companyDetailsDto.address !== undefined) {
+    formData.append(`address`, companyDetailsDto.address);
+  }
+  if (companyDetailsDto.contact_no !== undefined) {
+    formData.append(`contact_no`, companyDetailsDto.contact_no);
+  }
+  if (companyDetailsDto.website !== undefined) {
+    formData.append(`website`, companyDetailsDto.website);
+  }
+  if (companyDetailsDto.license_number !== undefined) {
+    formData.append(`license_number`, companyDetailsDto.license_number);
+  }
+  formData.append(`years_in_business`, companyDetailsDto.years_in_business);
+  formData.append(`employees_number`, companyDetailsDto.employees_number);
+  if (companyDetailsDto.created_at !== undefined) {
+    formData.append(`created_at`, companyDetailsDto.created_at);
+  }
+
+  return customFetcher<void>({
+    url: `/company`,
+    method: "POST",
+    headers: { "Content-Type": "multipart/form-data" },
+    data: formData,
+    signal,
+  });
+};
+
+export const getCompanyControllerCreateMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof companyControllerCreate>>,
+    TError,
+    { data: CompanyDetailsDto },
+    TContext
+  >;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof companyControllerCreate>>,
+  TError,
+  { data: CompanyDetailsDto },
+  TContext
+> => {
+  const mutationKey = ["companyControllerCreate"];
+  const { mutation: mutationOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof companyControllerCreate>>,
+    { data: CompanyDetailsDto }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return companyControllerCreate(data);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type CompanyControllerCreateMutationResult = NonNullable<
+  Awaited<ReturnType<typeof companyControllerCreate>>
+>;
+export type CompanyControllerCreateMutationBody = CompanyDetailsDto;
+export type CompanyControllerCreateMutationError = unknown;
+
+export const useCompanyControllerCreate = <
+  TError = unknown,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof companyControllerCreate>>,
+      TError,
+      { data: CompanyDetailsDto },
+      TContext
+    >;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof companyControllerCreate>>,
+  TError,
+  { data: CompanyDetailsDto },
+  TContext
+> => {
+  const mutationOptions = getCompanyControllerCreateMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};
+
 export const companyControllerUpload = (
   id: string,
   uploadDocDto: UploadDocDto,
@@ -4300,83 +4402,6 @@ export const useCompanyControllerUpload = <
   TContext
 > => {
   const mutationOptions = getCompanyControllerUploadMutationOptions(options);
-
-  return useMutation(mutationOptions, queryClient);
-};
-
-export const companyControllerCreate = (
-  formData: FormData,
-  signal?: AbortSignal,
-) => {
-  return customFetcher<CommonResponseDto>({
-    url: `/company`,
-    method: "POST",
-    headers: { "Content-Type": "multipart/form-data" },
-    data: formData,
-    signal,
-  });
-};
-
-export const getCompanyControllerCreateMutationOptions = <
-  TError = unknown,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof companyControllerCreate>>,
-    TError,
-    { data: FormData },
-    TContext
-  >;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof companyControllerCreate>>,
-  TError,
-  { data: FormData },
-  TContext
-> => {
-  const mutationKey = ["companyControllerCreate"];
-  const { mutation: mutationOptions } = options
-    ? options.mutation &&
-      "mutationKey" in options.mutation &&
-      options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey } };
-
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof companyControllerCreate>>,
-    { data: FormData }
-  > = (props) => {
-    const { data } = props ?? {};
-
-    return companyControllerCreate(data);
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type CompanyControllerCreateMutationResult = NonNullable<
-  Awaited<ReturnType<typeof companyControllerCreate>>
->;
-export type CompanyControllerCreateMutationBody = FormData;
-export type CompanyControllerCreateMutationError = unknown;
-
-export const useCompanyControllerCreate = <TError = unknown, TContext = unknown>(
-  options?: {
-    mutation?: UseMutationOptions<
-      Awaited<ReturnType<typeof companyControllerCreate>>,
-      TError,
-      { data: FormData },
-      TContext
-    >;
-  },
-  queryClient?: QueryClient,
-): UseMutationResult<
-  Awaited<ReturnType<typeof companyControllerCreate>>,
-  TError,
-  { data: FormData },
-  TContext
-> => {
-  const mutationOptions = getCompanyControllerCreateMutationOptions(options);
 
   return useMutation(mutationOptions, queryClient);
 };

--- a/dashboard/app/hooks/useCompany.ts
+++ b/dashboard/app/hooks/useCompany.ts
@@ -1,4 +1,9 @@
-import { useCompanyControllerUpload, type UploadDocDto } from "@/app/api";
+import {
+  useCompanyControllerUpload,
+  useCompanyControllerCreate,
+  type UploadDocDto,
+  type CompanyDetailsDto,
+} from "@/app/api";
 import { parseError } from "../utils/parseError";
 
 export function useCompanyUploadMutation() {
@@ -7,6 +12,15 @@ export function useCompanyUploadMutation() {
     ...mutation,
     uploadCompanyDocuments: (id: string, data: UploadDocDto) =>
       mutation.mutateAsync({ id, data }),
+    error: parseError(mutation.error),
+  };
+}
+
+export function useCreateCompanyMutation() {
+  const mutation = useCompanyControllerCreate();
+  return {
+    ...mutation,
+    createCompany: (data: CompanyDetailsDto) => mutation.mutateAsync({ data }),
     error: parseError(mutation.error),
   };
 }

--- a/dashboard/app/hooks/useCompany.ts
+++ b/dashboard/app/hooks/useCompany.ts
@@ -1,26 +1,11 @@
-import {
-  useCompanyControllerUpload,
-  useCompanyControllerCreate,
-  type UploadDocDto,
-  type CompanyDetailsDto,
-} from "@/app/api";
+import { useCompanyControllerCreate } from "@/app/api";
 import { parseError } from "../utils/parseError";
-
-export function useCompanyUploadMutation() {
-  const mutation = useCompanyControllerUpload();
-  return {
-    ...mutation,
-    uploadCompanyDocuments: (id: string, data: UploadDocDto) =>
-      mutation.mutateAsync({ id, data }),
-    error: parseError(mutation.error),
-  };
-}
 
 export function useCreateCompanyMutation() {
   const mutation = useCompanyControllerCreate();
   return {
     ...mutation,
-    createCompany: (data: CompanyDetailsDto) => mutation.mutateAsync({ data }),
+    createCompany: (data: FormData) => mutation.mutateAsync({ data }),
     error: parseError(mutation.error),
   };
 }


### PR DESCRIPTION
## Summary
- expose company ID when registering admins
- use returned ID to upload documents in provider registration page

## Testing
- `npm test --workspaces` *(fails: jest not found & network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6888d2652c5c83209fc5ae4417735e4c