### PR TITLE
Load profile data from getMe hook

### DIFF
--- a/backend/src/api/auth/auth.service.ts
+++ b/backend/src/api/auth/auth.service.ts
@@ -139,7 +139,7 @@ export class AuthService {
     const { data: profile } = await req.supabase
       .from('user_details')
       .select(
-        `first_name, last_name, phone, bio,
+        `first_name, last_name, phone, bio, status,
         policyholder_details(address, date_of_birth, occupation),
         admin_details(company:companies(name, address, contact_no, license_number))`,
       )
@@ -158,6 +158,7 @@ export class AuthService {
       lastName: profile?.last_name ?? '',
       phone: profile?.phone ?? '',
       bio: profile?.bio ?? '',
+      status: profile?.status ?? '',
     });
 
     if (appMeta.role === UserRole.POLICYHOLDER) {

--- a/backend/src/api/auth/dto/requests/login.dto.ts
+++ b/backend/src/api/auth/dto/requests/login.dto.ts
@@ -3,7 +3,6 @@ import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
 
 export class LoginDto {
   @ApiProperty({
-    example: 'johndoe@example.com',
     description: 'User email address',
   })
   @IsEmail({}, { message: 'Email must be a valid email address' })
@@ -11,7 +10,6 @@ export class LoginDto {
   email!: string;
 
   @ApiProperty({
-    example: 'secret123',
     description: 'Password for the user',
   })
   @IsString({ message: 'Password must be a string' })

--- a/backend/src/api/auth/dto/responses/auth-user.dto.ts
+++ b/backend/src/api/auth/dto/responses/auth-user.dto.ts
@@ -35,6 +35,9 @@ export class AuthUserResponseDto {
   @ApiProperty({ required: false })
   bio?: string | null;
 
+  @ApiProperty({ example: 'active' })
+  status?: string;
+
   // Policyholder specific fields
   @ApiProperty({ required: false })
   address?: string | null;

--- a/backend/swagger-spec.json
+++ b/backend/swagger-spec.json
@@ -1590,6 +1590,10 @@
           "bio": {
             "type": "object"
           },
+          "status": {
+            "type": "string",
+            "example": "active"
+          },
           "address": {
             "type": "object"
           },
@@ -1619,7 +1623,8 @@
           "username",
           "role",
           "lastSignInAt",
-          "provider"
+          "provider",
+          "status"
         ]
       },
       "LoginResponseDto": {
@@ -1638,12 +1643,10 @@
         "properties": {
           "email": {
             "type": "string",
-            "example": "johndoe@example.com",
             "description": "User email address"
           },
           "password": {
             "type": "string",
-            "example": "secret123",
             "description": "Password for the user"
           }
         },

--- a/dashboard/app/(admin)/admin/profile/page.tsx
+++ b/dashboard/app/(admin)/admin/profile/page.tsx
@@ -46,6 +46,8 @@ export default function AdminProfile() {
   const [notifications, setNotifications] = useState(defaultNotifications);
   const { data } = useMeQuery();
 
+  console.log(data);
+
   useEffect(() => {
     if (data?.data) {
       const user = data.data;

--- a/dashboard/app/(admin)/admin/profile/page.tsx
+++ b/dashboard/app/(admin)/admin/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -15,6 +15,7 @@ import {
   activityLog,
   permissions,
 } from "@/public/data/admin/profileData";
+import { useMeQuery } from "@/hooks/useAuth";
 import {
   User,
   Shield,
@@ -43,6 +44,29 @@ export default function AdminProfile() {
   const [isEditing, setIsEditing] = useState(false);
   const [profileData, setProfileData] = useState(defaultProfileData);
   const [notifications, setNotifications] = useState(defaultNotifications);
+  const { data } = useMeQuery();
+
+  useEffect(() => {
+    if (data?.data) {
+      const user = data.data;
+      setProfileData((prev) => ({
+        ...prev,
+        firstName: (user.firstName as string) ?? prev.firstName,
+        lastName: (user.lastName as string) ?? prev.lastName,
+        email: user.email ?? prev.email,
+        phone: (user.phone as string) ?? prev.phone,
+        address: (user.address as string) ?? prev.address,
+        dateOfBirth: (user.dateOfBirth as string) ?? prev.dateOfBirth,
+        companyName: (user.companyName as string) ?? prev.companyName,
+        companyAddress: (user.companyAddress as string) ?? prev.companyAddress,
+        companyContactNo:
+          (user.companyContactNo as string) ?? prev.companyContactNo,
+        companyLicenseNo:
+          (user.companyLicenseNo as string) ?? prev.companyLicenseNo,
+        bio: (user.bio as string) ?? prev.bio,
+      }));
+    }
+  }, [data]);
 
   const handleSave = () => {
     setIsEditing(false);

--- a/dashboard/app/(policyholder)/policyholder/profile/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/profile/page.tsx
@@ -47,6 +47,7 @@ export default function Profile() {
         dateOfBirth: (user.dateOfBirth as string) ?? prev.dateOfBirth,
         occupation: (user.occupation as string) ?? prev.occupation,
         bio: (user.bio as string) ?? prev.bio,
+        status: (user.status as string) ?? prev.status,
       }));
     }
   }, [data]);
@@ -132,7 +133,8 @@ export default function Profile() {
                 </p>
                 <Badge className="status-badge status-active">
                   <Shield className="w-3 h-3 mr-1" />
-                  KYC Verified
+                  {profileData.status.charAt(0).toUpperCase() +
+                    profileData.status.slice(1)}
                 </Badge>
               </CardContent>
             </Card>
@@ -357,8 +359,8 @@ export default function Profile() {
                               value.status === "verified"
                                 ? "bg-gradient-to-r from-emerald-500 to-green-600"
                                 : value.status === "pending"
-                                ? "bg-gradient-to-r from-yellow-500 to-orange-500"
-                                : "bg-gradient-to-r from-red-500 to-pink-500"
+                                  ? "bg-gradient-to-r from-yellow-500 to-orange-500"
+                                  : "bg-gradient-to-r from-red-500 to-pink-500"
                             }`}
                           >
                             {getStatusIcon(value.status)}
@@ -576,10 +578,10 @@ export default function Profile() {
                               activity.type === "claim"
                                 ? "bg-gradient-to-r from-blue-500 to-cyan-500"
                                 : activity.type === "payment"
-                                ? "bg-gradient-to-r from-emerald-500 to-green-600"
-                                : activity.type === "policy"
-                                ? "bg-gradient-to-r from-purple-500 to-indigo-500"
-                                : "bg-gradient-to-r from-slate-500 to-slate-600"
+                                  ? "bg-gradient-to-r from-emerald-500 to-green-600"
+                                  : activity.type === "policy"
+                                    ? "bg-gradient-to-r from-purple-500 to-indigo-500"
+                                    : "bg-gradient-to-r from-slate-500 to-slate-600"
                             }`}
                           >
                             {activity.type === "claim" && (

--- a/dashboard/app/(policyholder)/policyholder/profile/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -26,11 +26,30 @@ import {
   kycStatus,
   activityLog,
 } from "@/public/data/policyholder/profileData";
+import { useMeQuery } from "@/hooks/useAuth";
 
 export default function Profile() {
   const [isEditing, setIsEditing] = useState(false);
   const [profileData, setProfileData] = useState(initialProfileData);
   const [notifications, setNotifications] = useState(initialNotifications);
+  const { data } = useMeQuery();
+
+  useEffect(() => {
+    if (data?.data) {
+      const user = data.data;
+      setProfileData((prev) => ({
+        ...prev,
+        firstName: (user.firstName as string) ?? prev.firstName,
+        lastName: (user.lastName as string) ?? prev.lastName,
+        email: user.email ?? prev.email,
+        phone: (user.phone as string) ?? prev.phone,
+        address: (user.address as string) ?? prev.address,
+        dateOfBirth: (user.dateOfBirth as string) ?? prev.dateOfBirth,
+        occupation: (user.occupation as string) ?? prev.occupation,
+        bio: (user.bio as string) ?? prev.bio,
+      }));
+    }
+  }, [data]);
   const handleSave = () => {
     setIsEditing(false);
     // Here you would typically save to backend

--- a/dashboard/app/(system-admin)/system-admin/profile/page.tsx
+++ b/dashboard/app/(system-admin)/system-admin/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -45,12 +45,36 @@ import {
   systemPermissions,
   securitySettings,
 } from "@/public/data/system-admin/profileData";
+import { useMeQuery } from "@/hooks/useAuth";
 
 export default function SystemAdminProfile() {
   const [isEditing, setIsEditing] = useState(false);
   const [profileData, setProfileData] = useState(initialProfileData);
 
   const [notifications, setNotifications] = useState(initialNotifications);
+  const { data } = useMeQuery();
+
+  useEffect(() => {
+    if (data?.data) {
+      const user = data.data;
+      setProfileData((prev) => ({
+        ...prev,
+        firstName: (user.firstName as string) ?? prev.firstName,
+        lastName: (user.lastName as string) ?? prev.lastName,
+        email: user.email ?? prev.email,
+        phone: (user.phone as string) ?? prev.phone,
+        address: (user.address as string) ?? prev.address,
+        dateOfBirth: (user.dateOfBirth as string) ?? prev.dateOfBirth,
+        companyName: (user.companyName as string) ?? prev.companyName,
+        companyAddress: (user.companyAddress as string) ?? prev.companyAddress,
+        companyContactNo:
+          (user.companyContactNo as string) ?? prev.companyContactNo,
+        companyLicenseNo:
+          (user.companyLicenseNo as string) ?? prev.companyLicenseNo,
+        bio: (user.bio as string) ?? prev.bio,
+      }));
+    }
+  }, [data]);
   // Data moved to public/data/system-admin/profileData.ts
 
   const handleSave = () => {

--- a/dashboard/hooks/useAuth.ts
+++ b/dashboard/hooks/useAuth.ts
@@ -3,7 +3,11 @@ import { useAuthControllerRegister, type RegisterDto } from "@/api";
 import { parseError } from "@/utils/parseError";
 import { useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { authControllerLogout, getAuthControllerGetMeQueryKey } from "@/api";
+import {
+  authControllerLogout,
+  getAuthControllerGetMeQueryKey,
+  useAuthControllerGetMe,
+} from "@/api";
 
 export function useLoginMutation() {
   const mutation = useAuthControllerLogin();
@@ -38,6 +42,15 @@ export function useLogout() {
   }, [queryClient]);
 
   return { logout };
+}
+
+export function useMeQuery() {
+  const query = useAuthControllerGetMe();
+
+  return {
+    ...query,
+    error: parseError(query.error),
+  };
 }
 
 export default function useAuth() {

--- a/dashboard/public/data/policyholder/profileData.ts
+++ b/dashboard/public/data/policyholder/profileData.ts
@@ -6,7 +6,8 @@ export const profileData = {
   address: '123 Main Street, New York, NY 10001',
   dateOfBirth: '1990-05-15',
   occupation: 'Software Engineer',
-  bio: 'Blockchain enthusiast and early adopter of decentralized insurance solutions.'
+  bio: 'Blockchain enthusiast and early adopter of decentralized insurance solutions.',
+  status: 'active'
 };
 
 export const notifications = {


### PR DESCRIPTION
## Summary
- expose `useMeQuery` in `useAuth` to fetch `/auth/me`
- hydrate profile pages (admin, system admin, policyholder) with user info from `getMe`

## Testing
- `npm --workspace=dashboard run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889bd3dbcd8832084380f0a98f26698