### PR TITLE
Fix logout and use update hook

### DIFF
--- a/backend/src/api/auth/auth.controller.ts
+++ b/backend/src/api/auth/auth.controller.ts
@@ -3,7 +3,7 @@ import {
   Controller,
   Get,
   Post,
-  Request,
+  Req,
   Res,
   UseGuards,
 } from '@nestjs/common';
@@ -15,6 +15,7 @@ import { LoginResponseDto } from './dto/responses/login.dto';
 import { AuthGuard } from './auth.guard';
 import { ApiCommonResponse, CommonResponseDto } from '../../common/common.dto';
 import { AuthenticatedRequest } from 'src/supabase/types/express';
+import { Request } from 'express';
 import { AuthUserResponseDto } from './dto/responses/auth-user.dto';
 import { Response } from 'express';
 
@@ -38,10 +39,9 @@ export class AuthController {
     return this.authService.register(dto);
   }
 
-  @UseGuards(AuthGuard)
   @Post('logout')
   async logout(
-    @Request() req: AuthenticatedRequest,
+    @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ) {
     return this.authService.signOut(req, res);

--- a/dashboard/app/(admin)/admin/profile/page.tsx
+++ b/dashboard/app/(admin)/admin/profile/page.tsx
@@ -16,6 +16,8 @@ import {
   permissions,
 } from "@/public/data/admin/profileData";
 import { useMeQuery } from "@/hooks/useAuth";
+import { useUpdateUserMutation } from "@/hooks/useUsers";
+import { useToast } from "@/components/shared/ToastProvider";
 import {
   User,
   Shield,
@@ -45,6 +47,8 @@ export default function AdminProfile() {
   const [profileData, setProfileData] = useState(defaultProfileData);
   const [notifications, setNotifications] = useState(defaultNotifications);
   const { data } = useMeQuery();
+  const { updateUser, isPending } = useUpdateUserMutation();
+  const { printMessage } = useToast();
 
   console.log(data);
 
@@ -70,9 +74,27 @@ export default function AdminProfile() {
     }
   }, [data]);
 
-  const handleSave = () => {
-    setIsEditing(false);
-    // Here you would typically save to backend
+  const handleSave = async () => {
+    if (!data?.data?.id) return;
+    try {
+      await updateUser(data.data.id, {
+        firstName: profileData.firstName,
+        lastName: profileData.lastName,
+        phone: profileData.phone,
+        bio: profileData.bio,
+        company: {
+          name: profileData.companyName,
+          address: profileData.companyAddress,
+          contact_no: profileData.companyContactNo,
+          license_number: profileData.companyLicenseNo,
+        },
+      });
+      printMessage("Profile updated", "success");
+      setIsEditing(false);
+    } catch (err) {
+      console.error(err);
+      printMessage("Update failed", "error");
+    }
   };
 
   const handleCancel = () => {
@@ -229,6 +251,7 @@ export default function AdminProfile() {
                         </Button>
                         <Button
                           onClick={handleSave}
+                          disabled={isPending}
                           className="gradient-accent text-white floating-button"
                         >
                           <Save className="w-4 h-4 mr-2" />

--- a/dashboard/app/(policyholder)/policyholder/profile/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/profile/page.tsx
@@ -27,12 +27,16 @@ import {
   activityLog,
 } from "@/public/data/policyholder/profileData";
 import { useMeQuery } from "@/hooks/useAuth";
+import { useUpdateUserMutation } from "@/hooks/useUsers";
+import { useToast } from "@/components/shared/ToastProvider";
 
 export default function Profile() {
   const [isEditing, setIsEditing] = useState(false);
   const [profileData, setProfileData] = useState(initialProfileData);
   const [notifications, setNotifications] = useState(initialNotifications);
   const { data } = useMeQuery();
+  const { updateUser, isPending } = useUpdateUserMutation();
+  const { printMessage } = useToast();
 
   useEffect(() => {
     if (data?.data) {
@@ -51,9 +55,24 @@ export default function Profile() {
       }));
     }
   }, [data]);
-  const handleSave = () => {
-    setIsEditing(false);
-    // Here you would typically save to backend
+  const handleSave = async () => {
+    if (!data?.data?.id) return;
+    try {
+      await updateUser(data.data.id, {
+        firstName: profileData.firstName,
+        lastName: profileData.lastName,
+        phone: profileData.phone,
+        bio: profileData.bio,
+        dateOfBirth: profileData.dateOfBirth,
+        occupation: profileData.occupation,
+        address: profileData.address,
+      });
+      printMessage("Profile updated", "success");
+      setIsEditing(false);
+    } catch (err) {
+      console.error(err);
+      printMessage("Update failed", "error");
+    }
   };
 
   const handleCancel = () => {
@@ -185,6 +204,7 @@ export default function Profile() {
                         </Button>
                         <Button
                           onClick={handleSave}
+                          disabled={isPending}
                           className="gradient-accent text-white floating-button"
                         >
                           <Save className="w-4 h-4 mr-2" />


### PR DESCRIPTION
## Summary
- adjust logout so cookies always clear
- integrate `useUpdateUserMutation` with profile pages for editing

## Testing
- `npx tsc -p backend/tsconfig.json --noEmit` *(fails: missing modules)*
- `npm --prefix backend install --silent` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6889d21bebf4832086cfc34ebd256387