### PR TITLE
Implement remember-me session refresh

### DIFF
--- a/backend/src/api/auth/auth.guard.ts
+++ b/backend/src/api/auth/auth.guard.ts
@@ -14,19 +14,52 @@ export class AuthGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
     const cookies = request.cookies as Record<string, string | undefined>;
-    const token = cookies?.access_token;
+    let token = cookies?.access_token;
+    const refreshToken = cookies?.refresh_token;
+    const res = context.switchToHttp().getResponse();
 
-    if (!token) {
+    if (token) {
+      request.supabase = this.supabaseService.createClientWithToken(token);
+      const { data, error } = await request.supabase.auth.getUser();
+      if (data?.user && !error) {
+        request.user = data.user;
+        return true;
+      }
+    }
+
+    if (!refreshToken) {
       throw new UnauthorizedException('Missing access token in cookie');
     }
 
-    request.supabase = this.supabaseService.createClientWithToken(token);
-    const { data, error } = await request.supabase.auth.getUser();
+    const supabase = this.supabaseService.createClientWithToken();
+    const { data: refreshData, error: refreshError } = await supabase.auth.setSession({
+      refresh_token: refreshToken,
+      access_token: token ?? '',
+    });
 
-    if (error || !data.user) {
+    if (refreshError || !refreshData.session) {
       throw new UnauthorizedException('Invalid or expired token');
     }
 
+    token = refreshData.session.access_token;
+    const maxAge = 30 * 24 * 60 * 60 * 1000;
+    res.cookie('access_token', refreshData.session.access_token, {
+      httpOnly: true,
+      secure: true,
+      maxAge,
+      sameSite: 'lax',
+      path: '/',
+    });
+    res.cookie('refresh_token', refreshData.session.refresh_token, {
+      httpOnly: true,
+      secure: true,
+      maxAge,
+      sameSite: 'lax',
+      path: '/',
+    });
+
+    request.supabase = this.supabaseService.createClientWithToken(token);
+    const { data } = await request.supabase.auth.getUser();
     request.user = data.user;
 
     return true;

--- a/backend/src/api/auth/dto/requests/login.dto.ts
+++ b/backend/src/api/auth/dto/requests/login.dto.ts
@@ -15,4 +15,10 @@ export class LoginDto {
   @IsString({ message: 'Password must be a string' })
   @IsNotEmpty({ message: 'Password is required' })
   password!: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'Keep the session for 30 days when checked',
+  })
+  rememberMe?: boolean;
 }

--- a/dashboard/api/index.ts
+++ b/dashboard/api/index.ts
@@ -84,6 +84,8 @@ export interface LoginDto {
   email: string;
   /** Password for the user */
   password: string;
+  /** Remember me for 30 days */
+  rememberMe?: boolean;
 }
 
 export type CompanyDetailsDtoYearsInBusiness =

--- a/dashboard/app/(auth)/auth/login/page.tsx
+++ b/dashboard/app/(auth)/auth/login/page.tsx
@@ -26,7 +26,11 @@ export default function LoginPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await login({ email: formData.email, password: formData.password });
+      await login({
+        email: formData.email,
+        password: formData.password,
+        rememberMe: formData.rememberMe,
+      });
       printMessage("Logged in successfully", "success");
       router.push("/");
       router.refresh();

--- a/dashboard/app/(policyholder)/policyholder/profile/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/profile/page.tsx
@@ -29,10 +29,12 @@ import {
 import { useMeQuery } from "@/hooks/useAuth";
 import { useUpdateUserMutation } from "@/hooks/useUsers";
 import { useToast } from "@/components/shared/ToastProvider";
+import ConfirmationDialog from "@/components/shared/ConfirmationDialog";
 import { ProfileResponseDto } from "@/api";
 
 export default function Profile() {
   const [isEditing, setIsEditing] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [profileData, setProfileData] =
     useState<ProfileResponseDto>(initialProfileData);
   const [notifications, setNotifications] = useState(initialNotifications);
@@ -73,9 +75,11 @@ export default function Profile() {
       });
       printMessage("Profile updated", "success");
       setIsEditing(false);
+      setConfirmOpen(false);
     } catch (err) {
       console.error(err);
       printMessage("Update failed", "error");
+      setConfirmOpen(false);
     }
   };
 
@@ -201,7 +205,7 @@ export default function Profile() {
                           Cancel
                         </Button>
                         <Button
-                          onClick={handleSave}
+                          onClick={() => setConfirmOpen(true)}
                           disabled={isPending}
                           className="gradient-accent text-white floating-button"
                         >
@@ -415,5 +419,12 @@ export default function Profile() {
         </div>
       </div>
     </div>
+    <ConfirmationDialog
+      open={confirmOpen}
+      title="Save Changes"
+      description="Are you sure you want to save these changes?"
+      onCancel={() => setConfirmOpen(false)}
+      onConfirm={handleSave}
+    />
   );
 }

--- a/dashboard/components/shared/ConfirmationDialog.tsx
+++ b/dashboard/components/shared/ConfirmationDialog.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+export interface ConfirmationDialogProps {
+  open: boolean;
+  title?: string;
+  description?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmationDialog({
+  open,
+  title = 'Confirm',
+  description = 'Are you sure you want to proceed?',
+  onConfirm,
+  onCancel,
+}: ConfirmationDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onCancel()}>
+      <DialogContent onOpenAutoFocus={(e) => e.preventDefault()} className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-slate-600 dark:text-slate-400">{description}</p>
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel} className="flex-1">
+            Cancel
+          </Button>
+          <Button onClick={onConfirm} className="flex-1 gradient-accent text-white">
+            Confirm
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/dashboard/components/shared/Navbar.tsx
+++ b/dashboard/components/shared/Navbar.tsx
@@ -125,7 +125,7 @@ export function Navbar({ role }: NavbarProps) {
   }
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 glass-card border-b border-white/20 dark:border-slate-700/50">
+    <nav className="fixed top-0 left-0 right-0 z-50 glass-card border-b border-white/20 dark:border-slate-700/50 overflow-visible">
       <div className="w-full px-4 sm:px-6 lg:px-8 xl:px-12 2xl:px-16">
         <div className="flex justify-between items-center h-16">
           {/* Logo */}


### PR DESCRIPTION
## Summary
- persist session with refresh token when `rememberMe` is checked
- add confirmation dialog component and use it on profile page
- keep navbar width steady when dropdown opens
- drop unnecessary `remember_me` cookie

## Testing
- `npm --prefix backend test` *(fails: jest not found)*
- `npm --prefix dashboard run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a59039ec08320a112fd07bca19d04