### PR TITLE
Add dynamic policy category counts

### DIFF
--- a/dashboard/app/(admin)/admin/policies/page.tsx
+++ b/dashboard/app/(admin)/admin/policies/page.tsx
@@ -43,7 +43,9 @@ import {
   usePoliciesQuery,
   useCreatePolicyMutation,
   useUploadPolicyDocumentsMutation,
+  useCategoryCountsQuery,
 } from "@/hooks/usePolicies";
+import { policyCategories } from "@/utils/policyCategories";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useMeQuery } from "@/hooks/useAuth";
 import { useToast } from '@/components/shared/ToastProvider';
@@ -64,6 +66,9 @@ export default function ManagePolicies() {
   const { createPolicy, error: createError } = useCreatePolicyMutation();
   const { uploadPolicyDocuments } = useUploadPolicyDocumentsMutation();
   const debouncedSearchTerm = useDebounce(searchTerm, 500);
+
+  const { data: categoryCountsData } = useCategoryCountsQuery();
+  const categoryCounts = categoryCountsData?.data || {};
 
   const [newPolicy, setNewPolicy] = useState({
     name: "",
@@ -666,6 +671,37 @@ export default function ManagePolicies() {
               </p>
             </CardContent>
           </Card>
+        </div>
+
+        {/* Policy Categories */}
+        <div className="grid md:grid-cols-3 gap-6 mb-8">
+          {policyCategories.map((category) => (
+            <Card
+              key={category.id}
+              className={`glass-card rounded-2xl cursor-pointer card-hover ${
+                filterCategory === category.id ? "ring-2 ring-emerald-500" : ""
+              }`}
+              onClick={() =>
+                handleFilterChange(() => setFilterCategory(category.id))
+              }
+            >
+              <CardContent className="flex items-center p-6">
+                <div
+                  className={`w-16 h-16 rounded-2xl bg-gradient-to-r ${category.color} flex items-center justify-center mr-4`}
+                >
+                  <category.icon className="w-8 h-8 text-white" />
+                </div>
+                <div>
+                  <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100">
+                    {category.name}
+                  </h3>
+                  <p className="text-sm text-slate-600 dark:text-slate-400">
+                    {categoryCounts[category.id] ?? 0} policies
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
         </div>
 
         {/* Tabs and Filters */}

--- a/dashboard/app/(policyholder)/policyholder/browse/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/browse/page.tsx
@@ -22,10 +22,9 @@ import {
   Filter,
   Star,
 } from "lucide-react";
-import {
-  policyCategories,
-  policies,
-} from "@/public/data/policyholder/browseData";
+import { policies } from "@/public/data/policyholder/browseData";
+import { policyCategories } from "@/utils/policyCategories";
+import { useCategoryCountsQuery } from "@/hooks/usePolicies";
 import PolicyDetailsDialog, {
   Policy,
 } from "@/components/shared/PolicyDetailsDialog";
@@ -41,6 +40,8 @@ export default function BrowsePolicies() {
   const [currentPage, setCurrentPage] = useState(1);
   const [showDetails, setShowDetails] = useState(false);
   const [selectedPolicy, setSelectedPolicy] = useState<Policy | null>(null);
+  const { data: categoryCountsData } = useCategoryCountsQuery();
+  const categoryCounts = categoryCountsData?.data || {};
   const filteredPolicies = useMemo(() => {
     let filtered = policies.filter((policy) => {
       const matchesSearch =
@@ -142,8 +143,7 @@ export default function BrowsePolicies() {
                     {category.name}
                   </h3>
                   <p className="text-sm text-slate-600 dark:text-slate-400">
-                    {policies.filter((p) => p.category === category.id).length}{" "}
-                    policies available
+                    {categoryCounts[category.id] ?? 0} policies available
                   </p>
                 </div>
               </CardContent>

--- a/dashboard/utils/policyCategories.ts
+++ b/dashboard/utils/policyCategories.ts
@@ -1,0 +1,7 @@
+import { Heart, Plane, Sprout } from 'lucide-react';
+
+export const policyCategories = [
+  { id: 'health', name: 'Health Insurance', icon: Heart, color: 'from-red-500 to-pink-500' },
+  { id: 'travel', name: 'Travel Insurance', icon: Plane, color: 'from-blue-500 to-cyan-500' },
+  { id: 'crop', name: 'Crop Insurance', icon: Sprout, color: 'from-green-500 to-emerald-500' },
+] as const;


### PR DESCRIPTION
## Summary
- share policy categories constants
- load category counts on policy browse page
- display same data on manage policies page

## Testing
- `npm --prefix backend test` *(fails: jest not found)*
- `npm --prefix dashboard run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b743537f08320bc03b2b0e1bde683