### PR TITLE
Update policy management and claim review

### DIFF
--- a/backend/src/api/auth/dto/responses/auth-user.dto.ts
+++ b/backend/src/api/auth/dto/responses/auth-user.dto.ts
@@ -24,42 +24,42 @@ export class AuthUserResponseDto {
 
   // General profile fields
   @ApiProperty({ required: false })
-  firstName?: string | null;
+  firstName?: string;
 
   @ApiProperty({ required: false })
-  lastName?: string | null;
+  lastName?: string;
 
   @ApiProperty({ required: false })
-  phone?: string | null;
+  phone?: string;
 
   @ApiProperty({ required: false })
-  bio?: string | null;
+  bio?: string;
 
   @ApiProperty({ example: 'active' })
   status?: string;
 
   // Policyholder specific fields
   @ApiProperty({ required: false })
-  address?: string | null;
+  address?: string;
 
   @ApiProperty({ required: false })
-  dateOfBirth?: string | null;
+  dateOfBirth?: string;
 
   @ApiProperty({ required: false })
-  occupation?: string | null;
+  occupation?: string;
 
   // Insurance admin specific fields
   @ApiProperty({ required: false })
-  companyName?: string | null;
+  companyName?: string;
 
   @ApiProperty({ required: false })
-  companyAddress?: string | null;
+  companyAddress?: string;
 
   @ApiProperty({ required: false })
-  companyContactNo?: string | null;
+  companyContactNo?: string;
 
   @ApiProperty({ required: false })
-  companyLicenseNo?: string | null;
+  companyLicenseNo?: string;
 
   constructor(dto: AuthUserResponseDto) {
     Object.assign(this, dto);

--- a/backend/src/api/company/company.controller.ts
+++ b/backend/src/api/company/company.controller.ts
@@ -3,13 +3,11 @@ import {
   Controller,
   Param,
   Post,
-  Req,
   UploadedFiles,
   UseInterceptors,
 } from '@nestjs/common';
 import { FilesInterceptor } from '@nestjs/platform-express';
 import { ApiBearerAuth, ApiConsumes } from '@nestjs/swagger';
-import { AuthenticatedRequest } from 'src/supabase/types/express';
 import { CompanyService } from './company.service';
 import { CommonResponseDto } from 'src/common/common.dto';
 import { UploadDocDto } from '../file/requests/document-upload.dto';
@@ -27,7 +25,6 @@ export class CompanyController {
     @Param('id') id: string,
     @Body() dto: UploadDocDto,
     @UploadedFiles() files: Array<Express.Multer.File>,
-    @Req() req: AuthenticatedRequest,
   ): Promise<CommonResponseDto> {
     return this.service.addDocuments(+id, files);
   }

--- a/backend/src/api/coverage/dto/responses/coverage-query.dto.ts
+++ b/backend/src/api/coverage/dto/responses/coverage-query.dto.ts
@@ -2,12 +2,16 @@ import { IsEnum, IsIn, IsOptional, IsString } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { PaginatedQueryDto } from 'src/common/paginated-query.dto';
 import { CoverageStatus } from '../requests/create-coverage.dto';
+import { PolicyCategory } from 'src/enums';
 
 export class FindCoverageQueryDto extends PaginatedQueryDto {
-  @ApiPropertyOptional({ description: 'Filter by policy category' })
+  @ApiPropertyOptional({
+    description: 'Filter by policy category',
+    enum: PolicyCategory,
+  })
   @IsOptional()
-  @IsString()
-  category?: string;
+  @IsEnum(PolicyCategory)
+  category?: PolicyCategory;
 
   @ApiPropertyOptional({
     description: 'Search keyword for policy name or description',

--- a/backend/src/api/file/file.service.ts
+++ b/backend/src/api/file/file.service.ts
@@ -77,8 +77,7 @@ export class FileService {
     filePath: string,
   ): Promise<void> {
     try {
-
-      const { data, error } = await supabase.storage
+      const { error } = await supabase.storage
         .from(this.BUCKET)
         .remove([filePath]);
 
@@ -90,7 +89,6 @@ export class FileService {
           'Failed to remove file from storage: ' + error.message,
         );
       }
-
     } catch (error) {
       if (error instanceof Error) {
         console.error('Caught error during file removal:', error.message);

--- a/backend/src/api/policy/dto/requests/create-policy.dto.ts
+++ b/backend/src/api/policy/dto/requests/create-policy.dto.ts
@@ -10,8 +10,10 @@ import {
   IsUUID,
   ValidateNested,
   IsDecimal,
+  IsEnum,
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
+import { PolicyCategory } from 'src/enums';
 
 export class CreateDocumentsDto {
   @ApiProperty({ example: 'Policy Terms', description: 'Document name' })
@@ -68,10 +70,10 @@ export class CreatePolicyDto {
   @IsNotEmpty()
   name!: string;
 
-  @ApiProperty({ example: 'health' })
-  @IsString()
+  @ApiProperty({ example: 'health', enum: PolicyCategory })
+  @IsEnum(PolicyCategory)
   @IsNotEmpty()
-  category!: string;
+  category!: PolicyCategory;
 
   @ApiProperty({ example: 'HealthSecure' })
   @IsString()

--- a/backend/src/api/policy/dto/requests/upload-policy-doc.dto.ts
+++ b/backend/src/api/policy/dto/requests/upload-policy-doc.dto.ts
@@ -2,17 +2,26 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsNotEmpty, IsString } from 'class-validator';
 
 export class UploadPolicyDocDto {
-  @ApiProperty({ example: 1, description: 'ID of the policy to attach the document to' })
+  @ApiProperty({
+    example: 1,
+    description: 'ID of the policy to attach the document to',
+  })
   @IsInt({ message: 'Policy ID must be an integer' })
   @IsNotEmpty({ message: 'Policy ID is required' })
   policy_id!: number;
 
-  @ApiProperty({ example: 'terms.pdf', description: 'Name of the uploaded document' })
+  @ApiProperty({
+    example: 'terms.pdf',
+    description: 'Name of the uploaded document',
+  })
   @IsString()
   @IsNotEmpty()
   name!: string;
 
-  @ApiProperty({ example: 'policy_documents/xyz.pdf', description: 'Path of the uploaded file in Supabase storage' })
+  @ApiProperty({
+    example: 'policy_documents/xyz.pdf',
+    description: 'Path of the uploaded file in Supabase storage',
+  })
   @IsString()
   @IsNotEmpty()
   path!: string;

--- a/backend/src/api/policy/dto/responses/policy-category.dto.ts
+++ b/backend/src/api/policy/dto/responses/policy-category.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PolicyCategoryCountStatsDto {
+  @ApiProperty()
+  travel!: number;
+
+  @ApiProperty()
+  health!: number;
+
+  @ApiProperty()
+  crop!: number;
+}

--- a/backend/src/api/policy/dto/responses/policy-query.dto.ts
+++ b/backend/src/api/policy/dto/responses/policy-query.dto.ts
@@ -28,4 +28,9 @@ export class FindPoliciesQueryDto extends PaginatedQueryDto {
   @IsOptional()
   @IsIn(['asc', 'desc'])
   sortOrder: 'asc' | 'desc' = 'asc';
+
+  @ApiPropertyOptional({ description: 'Filter by creator user id' })
+  @IsOptional()
+  @IsString()
+  userId?: string;
 }

--- a/backend/src/api/policy/dto/responses/policy-query.dto.ts
+++ b/backend/src/api/policy/dto/responses/policy-query.dto.ts
@@ -1,13 +1,17 @@
 // src/policies/dto/find-policies-query.dto.ts
-import { IsIn, IsOptional, IsString } from 'class-validator';
+import { IsEnum, IsIn, IsOptional, IsString } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { PaginatedQueryDto } from 'src/common/paginated-query.dto';
+import { PolicyCategory } from 'src/enums';
 
 export class FindPoliciesQueryDto extends PaginatedQueryDto {
-  @ApiPropertyOptional({ description: 'Filter by policy category' })
+  @ApiPropertyOptional({
+    description: 'Filter by policy category',
+    enum: PolicyCategory,
+  })
   @IsOptional()
-  @IsString()
-  category?: string;
+  @IsEnum(PolicyCategory)
+  category?: PolicyCategory;
 
   @ApiPropertyOptional({
     description: 'Search keyword for name or description',
@@ -18,10 +22,10 @@ export class FindPoliciesQueryDto extends PaginatedQueryDto {
 
   @ApiPropertyOptional({
     default: 'id',
-    enum: ['id', 'name', 'rating', 'premium', 'popularity'],
+    enum: ['id', 'name', 'rating', 'premium', 'sales'],
   })
   @IsOptional()
-  @IsIn(['id', 'name', 'rating', 'premium', 'popularity'])
+  @IsIn(['id', 'name', 'rating', 'premium', 'sales'])
   sortBy: string = 'id';
 
   @ApiPropertyOptional({ default: 'asc', enum: ['asc', 'desc'] })

--- a/backend/src/api/policy/dto/responses/policy.dto.ts
+++ b/backend/src/api/policy/dto/responses/policy.dto.ts
@@ -1,4 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { PolicyCategory } from 'src/enums';
 
 export class PolicyDocumentResponseDto {
   @ApiProperty()
@@ -24,7 +26,8 @@ export class PolicyResponseDto {
   name!: string;
 
   @ApiProperty()
-  category!: string;
+  @IsEnum(PolicyCategory)
+  category!: PolicyCategory;
 
   @ApiProperty()
   provider!: string;

--- a/backend/src/api/policy/policy.controller.ts
+++ b/backend/src/api/policy/policy.controller.ts
@@ -23,6 +23,7 @@ import { ApiCommonResponse, CommonResponseDto } from 'src/common/common.dto';
 import { PolicyResponseDto } from './dto/responses/policy.dto';
 import { FindPoliciesQueryDto } from './dto/responses/policy-query.dto';
 import { UploadDocDto } from '../file/requests/document-upload.dto';
+import { PolicyCategoryCountStatsDto } from './dto/responses/policy-category.dto';
 
 @Controller('policy')
 @ApiBearerAuth('supabase-auth')
@@ -84,7 +85,10 @@ export class PolicyController {
   @Get('/browse/categories')
   @UseGuards(AuthGuard)
   @ApiBearerAuth('supabase-auth')
-  async getCategoryCounts(@Req() req: AuthenticatedRequest) {
+  @ApiCommonResponse(PolicyCategoryCountStatsDto, false, 'Get category counts')
+  async getCategoryCounts(
+    @Req() req: AuthenticatedRequest,
+  ): Promise<CommonResponseDto<PolicyCategoryCountStatsDto>> {
     return this.policyService.getPolicyCountByCategory(req);
   }
 

--- a/backend/src/api/policy/policy.service.ts
+++ b/backend/src/api/policy/policy.service.ts
@@ -131,8 +131,8 @@ export class PolicyService {
     let dbQuery = req.supabase
       .from('policies')
       .select(
-        `*, 
-     policy_documents(*), 
+        `*,
+     policy_documents(*),
      policy_claim_type:policy_claim_type(
        claim_type:claim_types(name)
      )`,
@@ -141,8 +141,11 @@ export class PolicyService {
       .range(offset, offset + (query.limit || 5) - 1)
       .order(query.sortBy || 'id', {
         ascending: (query.sortOrder || 'asc') === 'asc',
-      })
-      .eq('created_by', req.user.id);
+      });
+
+    if (query.userId) {
+      dbQuery = dbQuery.eq('created_by', query.userId);
+    }
 
     if (query.category && query.category !== 'all') {
       dbQuery = dbQuery.eq('category', query.category);

--- a/backend/src/api/reviews/reviews.controller.ts
+++ b/backend/src/api/reviews/reviews.controller.ts
@@ -4,6 +4,7 @@ import { CreateReviewDto } from './dto/create-review.dto';
 import { AuthenticatedRequest } from 'src/supabase/types/express';
 import { AuthGuard } from '../auth/auth.guard';
 import { ApiBearerAuth } from '@nestjs/swagger';
+import { CommonResponseDto } from 'src/common/common.dto';
 
 @Controller('reviews')
 @ApiBearerAuth('supabase-auth')
@@ -16,7 +17,7 @@ export class ReviewsController {
     @Param('id') id: string,
     @Body() reviewDto: CreateReviewDto,
     @Req() req: AuthenticatedRequest,
-  ) {
+  ): Promise<CommonResponseDto> {
     return this.reviewsService.leavePolicyReview(+id, reviewDto, req);
   }
 

--- a/backend/src/api/reviews/reviews.controller.ts
+++ b/backend/src/api/reviews/reviews.controller.ts
@@ -1,12 +1,4 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Body,
-  Param,
-  Req,
-  UseGuards,
-} from '@nestjs/common';
+import { Controller, Post, Body, Param, Req, UseGuards } from '@nestjs/common';
 import { ReviewsService } from './reviews.service';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { AuthenticatedRequest } from 'src/supabase/types/express';

--- a/backend/src/api/reviews/reviews.service.ts
+++ b/backend/src/api/reviews/reviews.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { AuthenticatedRequest } from 'src/supabase/types/express';
+import { CommonResponseDto } from 'src/common/common.dto';
 
 @Injectable()
 export class ReviewsService {
@@ -12,7 +13,7 @@ export class ReviewsService {
     policyId: number,
     reviewDto: CreateReviewDto,
     req: AuthenticatedRequest,
-  ): Promise<any> {
+  ): Promise<CommonResponseDto> {
     // ✅ Step 1: Get authenticated user
     const { data: userData, error: userError } =
       await req.supabase.auth.getUser();
@@ -57,10 +58,10 @@ export class ReviewsService {
       );
     }
 
-    return {
+    return new CommonResponseDto({
       statusCode: 201,
       message: 'Review submitted successfully',
       data,
-    };
+    });
   }
 }

--- a/backend/src/api/user/user.controller.ts
+++ b/backend/src/api/user/user.controller.ts
@@ -17,7 +17,6 @@ import { RolesGuard } from '../auth/role.guard';
 import { ApiCommonResponse, CommonResponseDto } from 'src/common/common.dto';
 import { UserResponseDto } from './dto/respond/user.dto';
 import { UserStatsResponseDto } from './dto/respond/user-stats.dto';
-import { UserRole, UserStatus } from 'src/enums';
 import { FindUsersQueryDto } from './dto/responses/user-query.dto';
 
 @ApiTags('Users')

--- a/backend/src/enums/index.ts
+++ b/backend/src/enums/index.ts
@@ -27,6 +27,12 @@ export enum NumberOfEmployees {
   OVER_500 = '500+ employees',
 }
 
+export enum PolicyCategory {
+  HEALTH = 'health',
+  TRAVEL = 'travel',
+  CROP = 'crop',
+}
+
 export type AdminDetails = Partial<
   Database['public']['Tables']['admin_details']['Row']
 > & {

--- a/backend/src/supabase/types/supabase.types.ts
+++ b/backend/src/supabase/types/supabase.types.ts
@@ -298,7 +298,7 @@ export type Database = {
       };
       policies: {
         Row: {
-          category: string;
+          category: Database['public']['Enums']['policy_category'];
           coverage: number;
           created_by: string;
           description: string | null;
@@ -312,7 +312,7 @@ export type Database = {
           sales: number;
         };
         Insert: {
-          category: string;
+          category?: Database['public']['Enums']['policy_category'];
           coverage: number;
           created_by: string;
           description?: string | null;
@@ -326,7 +326,7 @@ export type Database = {
           sales?: number;
         };
         Update: {
-          category?: string;
+          category?: Database['public']['Enums']['policy_category'];
           coverage?: number;
           created_by?: string;
           description?: string | null;
@@ -577,6 +577,7 @@ export type Database = {
         | '51-200 employees'
         | '201-500 employees'
         | '500+ employees';
+      policy_category: 'health' | 'crop' | 'travel';
       role: 'admin' | 'user';
       user_status: 'active' | 'deactivated';
       years_in_business:
@@ -725,6 +726,7 @@ export const Constants = {
         '201-500 employees',
         '500+ employees',
       ],
+      policy_category: ['health', 'crop', 'travel'],
       role: ['admin', 'user'],
       user_status: ['active', 'deactivated'],
       years_in_business: [

--- a/backend/swagger-spec.json
+++ b/backend/swagger-spec.json
@@ -902,7 +902,12 @@
             "in": "query",
             "description": "Filter by policy category",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "health",
+                "travel",
+                "crop"
+              ]
             }
           },
           {
@@ -926,7 +931,7 @@
                 "name",
                 "rating",
                 "premium",
-                "popularity"
+                "sales"
               ]
             }
           },
@@ -941,6 +946,15 @@
                 "asc",
                 "desc"
               ]
+            }
+          },
+          {
+            "name": "userId",
+            "required": false,
+            "in": "query",
+            "description": "Filter by creator user id",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -1196,7 +1210,25 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": ""
+            "description": "Get category counts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/CommonResponseDto"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/PolicyCategoryCountStatsDto"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
           }
         },
         "security": [
@@ -1269,7 +1301,12 @@
             "in": "query",
             "description": "Filter by policy category",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "health",
+                "travel",
+                "crop"
+              ]
             }
           },
           {
@@ -1651,41 +1688,41 @@
             "type": "string"
           },
           "firstName": {
-            "type": "object"
+            "type": "string"
           },
           "lastName": {
-            "type": "object"
+            "type": "string"
           },
           "phone": {
-            "type": "object"
+            "type": "string"
           },
           "bio": {
-            "type": "object"
+            "type": "string"
           },
           "status": {
             "type": "string",
             "example": "active"
           },
           "address": {
-            "type": "object"
+            "type": "string"
           },
           "dateOfBirth": {
-            "type": "object"
+            "type": "string"
           },
           "occupation": {
-            "type": "object"
+            "type": "string"
           },
           "companyName": {
-            "type": "object"
+            "type": "string"
           },
           "companyAddress": {
-            "type": "object"
+            "type": "string"
           },
           "companyContactNo": {
-            "type": "object"
+            "type": "string"
           },
           "companyLicenseNo": {
-            "type": "object"
+            "type": "string"
           }
         },
         "required": [
@@ -2344,7 +2381,12 @@
           },
           "category": {
             "type": "string",
-            "example": "health"
+            "example": "health",
+            "enum": [
+              "health",
+              "travel",
+              "crop"
+            ]
           },
           "provider": {
             "type": "string",
@@ -2481,6 +2523,25 @@
           "policy_documents"
         ]
       },
+      "PolicyCategoryCountStatsDto": {
+        "type": "object",
+        "properties": {
+          "travel": {
+            "type": "number"
+          },
+          "health": {
+            "type": "number"
+          },
+          "crop": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "travel",
+          "health",
+          "crop"
+        ]
+      },
       "UpdatePolicyDto": {
         "type": "object",
         "properties": {
@@ -2490,7 +2551,12 @@
           },
           "category": {
             "type": "string",
-            "example": "health"
+            "example": "health",
+            "enum": [
+              "health",
+              "travel",
+              "crop"
+            ]
           },
           "provider": {
             "type": "string",

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -16,10 +16,12 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer())
+  it('/ (GET)', async () => {
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+    await request(app.getHttpServer())
       .get('/')
       .expect(200)
       .expect('Hello World!');
+    /* eslint-enable @typescript-eslint/no-unsafe-member-access */
   });
 });

--- a/dashboard/api/index.ts
+++ b/dashboard/api/index.ts
@@ -712,6 +712,7 @@ export type PolicyControllerFindAllParams = {
   search?: string;
   sortBy?: PolicyControllerFindAllSortBy;
   sortOrder?: PolicyControllerFindAllSortOrder;
+  userId?: string;
 };
 
 export type PolicyControllerFindAllSortBy =

--- a/dashboard/api/index.ts
+++ b/dashboard/api/index.ts
@@ -31,28 +31,6 @@ export interface CommonResponseDto {
   count?: number;
 }
 
-export type AuthUserResponseDtoFirstName = { [key: string]: unknown };
-
-export type AuthUserResponseDtoLastName = { [key: string]: unknown };
-
-export type AuthUserResponseDtoPhone = { [key: string]: unknown };
-
-export type AuthUserResponseDtoBio = { [key: string]: unknown };
-
-export type AuthUserResponseDtoAddress = { [key: string]: unknown };
-
-export type AuthUserResponseDtoDateOfBirth = { [key: string]: unknown };
-
-export type AuthUserResponseDtoOccupation = { [key: string]: unknown };
-
-export type AuthUserResponseDtoCompanyName = { [key: string]: unknown };
-
-export type AuthUserResponseDtoCompanyAddress = { [key: string]: unknown };
-
-export type AuthUserResponseDtoCompanyContactNo = { [key: string]: unknown };
-
-export type AuthUserResponseDtoCompanyLicenseNo = { [key: string]: unknown };
-
 export interface AuthUserResponseDto {
   id: string;
   email: string;
@@ -61,18 +39,18 @@ export interface AuthUserResponseDto {
   role: string;
   lastSignInAt: string;
   provider: string;
-  firstName?: AuthUserResponseDtoFirstName;
-  lastName?: AuthUserResponseDtoLastName;
-  phone?: AuthUserResponseDtoPhone;
-  bio?: AuthUserResponseDtoBio;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  bio?: string;
   status: string;
-  address?: AuthUserResponseDtoAddress;
-  dateOfBirth?: AuthUserResponseDtoDateOfBirth;
-  occupation?: AuthUserResponseDtoOccupation;
-  companyName?: AuthUserResponseDtoCompanyName;
-  companyAddress?: AuthUserResponseDtoCompanyAddress;
-  companyContactNo?: AuthUserResponseDtoCompanyContactNo;
-  companyLicenseNo?: AuthUserResponseDtoCompanyLicenseNo;
+  address?: string;
+  dateOfBirth?: string;
+  occupation?: string;
+  companyName?: string;
+  companyAddress?: string;
+  companyContactNo?: string;
+  companyLicenseNo?: string;
 }
 
 export interface LoginResponseDto {
@@ -335,7 +313,7 @@ export const CreateClaimDtoPriority = {
 
 export interface CreateClaimDto {
   /** ID of the policy associated with the claim */
-  policy_id: number;
+  coverage_id: number;
   /** Type of the claim */
   type: string;
   /** Priority of the claim */
@@ -392,7 +370,7 @@ export const UpdateClaimDtoPriority = {
 
 export interface UpdateClaimDto {
   /** ID of the policy associated with the claim */
-  policy_id?: number;
+  coverage_id?: number;
   /** Type of the claim */
   type?: string;
   /** Priority of the claim */
@@ -417,9 +395,19 @@ export const ClaimStatus = {
   claimed: "claimed",
 } as const;
 
+export type CreatePolicyDtoCategory =
+  (typeof CreatePolicyDtoCategory)[keyof typeof CreatePolicyDtoCategory];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const CreatePolicyDtoCategory = {
+  health: "health",
+  travel: "travel",
+  crop: "crop",
+} as const;
+
 export interface CreatePolicyDto {
   name: string;
-  category: string;
+  category: CreatePolicyDtoCategory;
   provider: string;
   coverage: number;
   durationDays: number;
@@ -455,9 +443,25 @@ export interface PolicyResponseDto {
   policy_documents: PolicyDocumentResponseDto[];
 }
 
+export interface PolicyCategoryCountStatsDto {
+  travel: number;
+  health: number;
+  crop: number;
+}
+
+export type UpdatePolicyDtoCategory =
+  (typeof UpdatePolicyDtoCategory)[keyof typeof UpdatePolicyDtoCategory];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const UpdatePolicyDtoCategory = {
+  health: "health",
+  travel: "travel",
+  crop: "crop",
+} as const;
+
 export interface UpdatePolicyDto {
   name?: string;
-  category?: string;
+  category?: UpdatePolicyDtoCategory;
   provider?: string;
   coverage?: number;
   durationDays?: number;
@@ -705,15 +709,28 @@ export type PolicyControllerFindAllParams = {
   /**
    * Filter by policy category
    */
-  category?: string;
+  category?: PolicyControllerFindAllCategory;
   /**
    * Search keyword for name or description
    */
   search?: string;
   sortBy?: PolicyControllerFindAllSortBy;
   sortOrder?: PolicyControllerFindAllSortOrder;
+  /**
+   * Filter by creator user id
+   */
   userId?: string;
 };
+
+export type PolicyControllerFindAllCategory =
+  (typeof PolicyControllerFindAllCategory)[keyof typeof PolicyControllerFindAllCategory];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const PolicyControllerFindAllCategory = {
+  health: "health",
+  travel: "travel",
+  crop: "crop",
+} as const;
 
 export type PolicyControllerFindAllSortBy =
   (typeof PolicyControllerFindAllSortBy)[keyof typeof PolicyControllerFindAllSortBy];
@@ -724,7 +741,7 @@ export const PolicyControllerFindAllSortBy = {
   name: "name",
   rating: "rating",
   premium: "premium",
-  popularity: "popularity",
+  sales: "sales",
 } as const;
 
 export type PolicyControllerFindAllSortOrder =
@@ -764,13 +781,20 @@ export type PolicyControllerRemove200AllOf = {
 export type PolicyControllerRemove200 = CommonResponseDto &
   PolicyControllerRemove200AllOf;
 
+export type PolicyControllerGetCategoryCounts200AllOf = {
+  data?: PolicyCategoryCountStatsDto;
+};
+
+export type PolicyControllerGetCategoryCounts200 = CommonResponseDto &
+  PolicyControllerGetCategoryCounts200AllOf;
+
 export type CoverageControllerFindAllParams = {
   page?: number;
   limit?: number;
   /**
    * Filter by policy category
    */
-  category?: string;
+  category?: CoverageControllerFindAllCategory;
   /**
    * Search keyword for policy name or description
    */
@@ -779,6 +803,16 @@ export type CoverageControllerFindAllParams = {
   sortBy?: CoverageControllerFindAllSortBy;
   sortOrder?: CoverageControllerFindAllSortOrder;
 };
+
+export type CoverageControllerFindAllCategory =
+  (typeof CoverageControllerFindAllCategory)[keyof typeof CoverageControllerFindAllCategory];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const CoverageControllerFindAllCategory = {
+  health: "health",
+  travel: "travel",
+  crop: "crop",
+} as const;
 
 export type CoverageControllerFindAllStatus =
   (typeof CoverageControllerFindAllStatus)[keyof typeof CoverageControllerFindAllStatus];
@@ -3484,7 +3518,7 @@ export function usePolicyControllerGetSummary<
 }
 
 export const policyControllerGetCategoryCounts = (signal?: AbortSignal) => {
-  return customFetcher<void>({
+  return customFetcher<PolicyControllerGetCategoryCounts200>({
     url: `/policy/browse/categories`,
     method: "GET",
     signal,

--- a/dashboard/app/(admin)/admin/claims/page.tsx
+++ b/dashboard/app/(admin)/admin/claims/page.tsx
@@ -16,7 +16,6 @@ import ClaimReviewDialog from "@/components/shared/ClaimReviewDialog";
 import { Pagination } from "@/components/shared/Pagination";
 import {
   useClaimControllerFindAll,
-  useClaimControllerUpdateClaimStatus,
   useClaimControllerGetStats,
 } from "@/api";
 import {
@@ -48,7 +47,6 @@ export default function ClaimsReview() {
   const claims = claimsData?.data ?? [];
 
   const { data: stats } = useClaimControllerGetStats({ query: {} });
-  const updateStatus = useClaimControllerUpdateClaimStatus();
 
   const filteredClaims = useMemo(() => {
     let filtered = claims.filter((claim: any) => {
@@ -123,13 +121,6 @@ export default function ClaimsReview() {
     }
   };
 
-  const handleApprove = (claimId: number) => {
-    updateStatus.mutate({ id: String(claimId), status: "approved" });
-  };
-
-  const handleReject = (claimId: number) => {
-    updateStatus.mutate({ id: String(claimId), status: "rejected" });
-  };
 
   return (
     <div className="section-spacing">
@@ -350,28 +341,7 @@ export default function ClaimsReview() {
                     />
                   </div>
 
-                  {(claim.status === "pending" ||
-                    claim.status === "under-review") && (
-                    <div className="flex space-x-2">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => handleReject(claim.id)}
-                        className="text-red-600 dark:text-red-400 border-red-200 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-900/20"
-                      >
-                        <X className="w-4 h-4 mr-1" />
-                        Reject
-                      </Button>
-                      <Button
-                        size="sm"
-                        onClick={() => handleApprove(claim.id)}
-                        className="gradient-accent text-white floating-button"
-                      >
-                        <CheckCircle className="w-4 h-4 mr-1" />
-                        Approve
-                      </Button>
-                    </div>
-                  )}
+                  {(claim.status === "pending" || claim.status === "under-review") && null}
                 </div>
               </CardContent>
             </Card>

--- a/dashboard/app/(admin)/admin/policies/page.tsx
+++ b/dashboard/app/(admin)/admin/policies/page.tsx
@@ -39,6 +39,8 @@ import {
   FileText,
   Download,
 } from "lucide-react";
+import PolicyDetailsDialog, { Policy } from "@/components/shared/PolicyDetailsDialog";
+import EditPolicyDialog from "@/components/shared/EditPolicyDialog";
 import {
   usePoliciesQuery,
   useCreatePolicyMutation,
@@ -54,6 +56,8 @@ export default function ManagePolicies() {
   const [filterCategory, setFilterCategory] = useState("all");
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [selectedPolicy, setSelectedPolicy] = useState<any>(null);
+  const [showDetails, setShowDetails] = useState(false);
+  const [showEdit, setShowEdit] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(15);
   const [uploadedTermsFiles, setUploadedTermsFiles] = useState<File[]>([]);
@@ -84,6 +88,7 @@ export default function ManagePolicies() {
     search: debouncedSearchTerm,
     page: currentPage,
     limit: itemsPerPage,
+    userId: meData?.id,
   });
 
   useEffect(() => {
@@ -98,7 +103,7 @@ export default function ManagePolicies() {
     }
   }, [error]);
 
-  const policies = (policiesData?.data || []).map((policy) => ({
+  const policies: Policy[] = (policiesData?.data || []).map((policy) => ({
     id: policy.id,
     name: policy.name,
     category: policy.category,
@@ -177,6 +182,21 @@ export default function ManagePolicies() {
   const handleFilterChange = (filterFn: () => void) => {
     filterFn();
     setCurrentPage(1);
+  };
+
+  const openDetails = (policy: Policy) => {
+    setSelectedPolicy(policy);
+    setShowDetails(true);
+  };
+
+  const openEdit = (policy: Policy) => {
+    setSelectedPolicy(policy);
+    setShowEdit(true);
+  };
+
+  const closeDialogs = () => {
+    setShowDetails(false);
+    setShowEdit(false);
   };
 
   const handleCreatePolicy = async () => {
@@ -869,6 +889,7 @@ export default function ManagePolicies() {
                       <Button
                         variant="outline"
                         className="flex-1 floating-button"
+                        onClick={() => openDetails(policy)}
                       >
                         <Eye className="w-4 h-4 mr-2" />
                         View Details
@@ -876,6 +897,7 @@ export default function ManagePolicies() {
                       <Button
                         variant="outline"
                         className="flex-1 floating-button"
+                        onClick={() => openEdit(policy)}
                       >
                         <Edit className="w-4 h-4 mr-2" />
                         Edit
@@ -915,6 +937,21 @@ export default function ManagePolicies() {
               Try adjusting your search criteria or create a new policy
             </p>
           </div>
+        )}
+
+        {selectedPolicy && (
+          <PolicyDetailsDialog
+            policy={selectedPolicy}
+            open={showDetails}
+            onClose={closeDialogs}
+          />
+        )}
+        {selectedPolicy && (
+          <EditPolicyDialog
+            policy={selectedPolicy}
+            open={showEdit}
+            onClose={closeDialogs}
+          />
         )}
       </div>
     </div>

--- a/dashboard/app/(admin)/admin/policies/page.tsx
+++ b/dashboard/app/(admin)/admin/policies/page.tsx
@@ -39,7 +39,9 @@ import {
   FileText,
   Download,
 } from "lucide-react";
-import PolicyDetailsDialog, { Policy } from "@/components/shared/PolicyDetailsDialog";
+import PolicyDetailsDialog, {
+  Policy,
+} from "@/components/shared/PolicyDetailsDialog";
 import EditPolicyDialog from "@/components/shared/EditPolicyDialog";
 import {
   usePoliciesQuery,
@@ -48,12 +50,15 @@ import {
 } from "@/hooks/usePolicies";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useMeQuery } from "@/hooks/useAuth";
-import { useToast } from '@/components/shared/ToastProvider';
+import { useToast } from "@/components/shared/ToastProvider";
+import { PolicyControllerFindAllCategory } from "@/api";
 
 export default function ManagePolicies() {
   const [activeTab, setActiveTab] = useState("all");
   const [searchTerm, setSearchTerm] = useState("");
-  const [filterCategory, setFilterCategory] = useState("all");
+  const [filterCategory, setFilterCategory] = useState(
+    PolicyControllerFindAllCategory.health
+  );
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [selectedPolicy, setSelectedPolicy] = useState<any>(null);
   const [showDetails, setShowDetails] = useState(false);
@@ -88,11 +93,10 @@ export default function ManagePolicies() {
     search: debouncedSearchTerm,
     page: currentPage,
     limit: itemsPerPage,
-    userId: meData?.id,
+    userId: meData?.data?.id,
   });
 
-  useEffect(() => {
-  }, [policiesData]);
+  useEffect(() => {}, [policiesData]);
 
   useEffect(() => {
     if (error) {
@@ -110,18 +114,18 @@ export default function ManagePolicies() {
     provider: policy.provider,
     coverage: policy.coverage ? `$${policy.coverage.toLocaleString()}` : "-",
     premium: policy.premium,
-    status: "active", 
-    sales: policy.sales, 
-    revenue: "-", 
-    created: "-", 
-    lastUpdated: "-", 
+    status: "active",
+    sales: policy.sales,
+    revenue: "-",
+    created: "-",
+    lastUpdated: "-",
     description:
       typeof policy.description === "string" ? policy.description : "",
     features: policy.claim_types || [],
-    terms: "", 
+    terms: "",
   }));
 
-  const getCategoryIcon = (category: string) => {
+  const getCategoryIcon = (category: PolicyControllerFindAllCategory) => {
     switch (category) {
       case "health":
         return Heart;
@@ -218,10 +222,15 @@ export default function ManagePolicies() {
           files: uploadedTermsFiles,
         });
       }
-      printMessage((res as any)?.message || "Policy created successfully", "success");
+      printMessage(
+        (res as any)?.message || "Policy created successfully",
+        "success"
+      );
     } catch (err) {
       printMessage(
-        typeof err === "string" ? err : createError || "Failed to create policy",
+        typeof err === "string"
+          ? err
+          : createError || "Failed to create policy",
         "error"
       );
     }
@@ -629,9 +638,6 @@ export default function ManagePolicies() {
                 </div>
                 <Badge className="status-badge status-active">Active</Badge>
               </div>
-              <h3 className="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-1">
-                {policies.filter((p) => p.status === "active").length}
-              </h3>
               <p className="text-slate-600 dark:text-slate-400">
                 Active Policies
               </p>
@@ -646,12 +652,6 @@ export default function ManagePolicies() {
                 </div>
                 <Badge className="status-badge status-pending">Draft</Badge>
               </div>
-              <h3 className="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-1">
-                {policies.filter((p) => p.status === "draft").length}
-              </h3>
-              <p className="text-slate-600 dark:text-slate-400">
-                Draft Policies
-              </p>
             </CardContent>
           </Card>
 
@@ -806,12 +806,6 @@ export default function ManagePolicies() {
                           </p>
                         </div>
                       </div>
-                      <Badge
-                        className={`status-badge ${getStatusColor(policy.status)}`}
-                      >
-                        {policy.status.charAt(0).toUpperCase() +
-                          policy.status.slice(1)}
-                      </Badge>
                     </div>
                   </CardHeader>
 
@@ -839,51 +833,51 @@ export default function ManagePolicies() {
                       </div>
                     </div>
 
-                    {policy.status === "active" && (
-                      <div className="grid grid-cols-2 gap-4 p-3 bg-slate-50/50 dark:bg-slate-700/30 rounded-lg">
-                        <div>
-                          <p className="text-sm text-slate-600 dark:text-slate-400">
-                            Sales
-                          </p>
-                          <p className="font-semibold text-slate-800 dark:text-slate-100">
-                            {policy.sales}
-                          </p>
-                        </div>
-                        <div>
-                          <p className="text-sm text-slate-600 dark:text-slate-400">
-                            Revenue
-                          </p>
-                          <p className="font-semibold text-slate-800 dark:text-slate-100">
-                            {policy.revenue}
-                          </p>
+                    <div className="grid grid-cols-2 gap-4 p-3 bg-slate-50/50 dark:bg-slate-700/30 rounded-lg">
+                      <div>
+                        <p className="text-sm text-slate-600 dark:text-slate-400">
+                          Sales
+                        </p>
+                        <p className="font-semibold text-slate-800 dark:text-slate-100">
+                          {policy.sales}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-sm text-slate-600 dark:text-slate-400">
+                          Revenue
+                        </p>
+                        <p className="font-semibold text-slate-800 dark:text-slate-100">
+                          {policy.revenue}
+                        </p>
+                      </div>
+                    </div>
+
+                    {policy.features && policy.features.length > 0 && (
+                      <div>
+                        <p className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                          Claim Type:
+                        </p>
+                        <div className="flex flex-wrap gap-1">
+                          {policy.features.slice(0, 3).map((feature, index) => (
+                            <Badge
+                              key={index}
+                              variant="secondary"
+                              className="text-xs bg-slate-200 dark:bg-slate-600/50 text-slate-700 dark:text-slate-300"
+                            >
+                              {feature}
+                            </Badge>
+                          ))}
+                          {policy.features.length > 3 && (
+                            <Badge
+                              variant="secondary"
+                              className="text-xs bg-slate-200 dark:bg-slate-600/50 text-slate-700 dark:text-slate-300"
+                            >
+                              +{policy.features.length - 3} more
+                            </Badge>
+                          )}
                         </div>
                       </div>
                     )}
-
-                    <div>
-                      <p className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
-                        Claim Type:
-                      </p>
-                      <div className="flex flex-wrap gap-1">
-                        {policy.features.slice(0, 3).map((feature, index) => (
-                          <Badge
-                            key={index}
-                            variant="secondary"
-                            className="text-xs bg-slate-200 dark:bg-slate-600/50 text-slate-700 dark:text-slate-300"
-                          >
-                            {feature}
-                          </Badge>
-                        ))}
-                        {policy.features.length > 3 && (
-                          <Badge
-                            variant="secondary"
-                            className="text-xs bg-slate-200 dark:bg-slate-600/50 text-slate-700 dark:text-slate-300"
-                          >
-                            +{policy.features.length - 3} more
-                          </Badge>
-                        )}
-                      </div>
-                    </div>
 
                     <div className="flex gap-2 pt-4 border-t border-slate-100 dark:border-slate-700">
                       <Button

--- a/dashboard/app/(policyholder)/policyholder/wallet/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/wallet/page.tsx
@@ -31,6 +31,7 @@ import {
   allTransactions,
 } from "@/public/data/policyholder/walletData";
 import WalletSection from "@/components/shared/WalletSectiom";
+import { Connect } from "@/components/shared/Connect";
 
 const ITEMS_PER_PAGE = 10;
 
@@ -127,6 +128,9 @@ export default function WalletPage() {
                 Manage your crypto assets and transaction history
               </p>
             </div>
+          </div>
+          <div className="ml-auto">
+            <Connect />
           </div>
         </div>
 

--- a/dashboard/app/(policyholder)/policyholder/wallet/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/wallet/page.tsx
@@ -31,7 +31,6 @@ import {
   allTransactions,
 } from "@/public/data/policyholder/walletData";
 import WalletSection from "@/components/shared/WalletSectiom";
-import { Connect } from "@/components/shared/Connect";
 
 const ITEMS_PER_PAGE = 10;
 
@@ -128,9 +127,6 @@ export default function WalletPage() {
                 Manage your crypto assets and transaction history
               </p>
             </div>
-          </div>
-          <div className="ml-auto">
-            <Connect />
           </div>
         </div>
 

--- a/dashboard/components/shared/ClaimReviewDialog.tsx
+++ b/dashboard/components/shared/ClaimReviewDialog.tsx
@@ -18,7 +18,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import { FileText, CheckCircle, X } from 'lucide-react';
+import { FileText } from 'lucide-react';
 
 import type { ReactNode } from 'react';
 
@@ -29,18 +29,15 @@ interface ClaimReviewDialogProps {
 
 export function ClaimReviewDialog({ claim, trigger }: ClaimReviewDialogProps) {
   const [open, setOpen] = useState(false);
-  const adjusters = ['Alice Brown', 'David Lee', 'Monica Garcia'];
   const [reviewForm, setReviewForm] = useState({
     status: claim.status || '',
     notes: '',
-    adjuster: '',
     reason: '',
     payment: '',
   });
   const [errors, setErrors] = useState({
     status: '',
     notes: '',
-    adjuster: '',
     reason: '',
     payment: '',
   });
@@ -48,7 +45,6 @@ export function ClaimReviewDialog({ claim, trigger }: ClaimReviewDialogProps) {
   const validateForm = () => {
     const newErrors: any = {};
     if (!reviewForm.status) newErrors.status = 'Status is required';
-    if (!reviewForm.adjuster) newErrors.adjuster = 'Select an adjuster';
     if (!reviewForm.notes) newErrors.notes = 'Assessment notes are required';
     if (
       (reviewForm.status === 'rejected' || reviewForm.status === 'under-review') &&
@@ -67,30 +63,9 @@ export function ClaimReviewDialog({ claim, trigger }: ClaimReviewDialogProps) {
     return Object.keys(newErrors).length === 0;
   };
 
-  const handleApprove = () => {
-    setReviewForm({ ...reviewForm, status: 'approved' });
-    if (!validateForm()) return;
-    console.log('Approving claim:', claim.id, reviewForm);
-    setOpen(false);
-  };
-
-  const handleReject = () => {
-    setReviewForm({ ...reviewForm, status: 'rejected' });
-    if (!validateForm()) return;
-    console.log('Rejecting claim:', claim.id, reviewForm);
-    setOpen(false);
-  };
-
   const handleSaveChanges = () => {
     if (!validateForm()) return;
     console.log('Saving claim:', claim.id, reviewForm);
-    setOpen(false);
-  };
-
-  const handleRequestInfo = () => {
-    setReviewForm({ ...reviewForm, status: 'under-review' });
-    if (!validateForm()) return;
-    console.log('Requesting additional info for', claim.id);
     setOpen(false);
   };
 
@@ -103,11 +78,10 @@ export function ClaimReviewDialog({ claim, trigger }: ClaimReviewDialogProps) {
           setReviewForm({
             status: claim.status || '',
             notes: '',
-            adjuster: '',
             reason: '',
             payment: '',
           });
-          setErrors({ status: '', notes: '', adjuster: '', reason: '', payment: '' });
+          setErrors({ status: '', notes: '', reason: '', payment: '' });
         }
       }}
     >
@@ -229,20 +203,6 @@ export function ClaimReviewDialog({ claim, trigger }: ClaimReviewDialogProps) {
                 </Select>
                 {errors.status && <p className="text-sm text-red-600 mt-1">{errors.status}</p>}
               </div>
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">Claims Adjuster</label>
-                <Select value={reviewForm.adjuster} onValueChange={(value) => setReviewForm({ ...reviewForm, adjuster: value })}>
-                  <SelectTrigger className="form-input">
-                    <SelectValue placeholder="Assign adjuster" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {adjusters.map((adj) => (
-                      <SelectItem key={adj} value={adj}>{adj}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {errors.adjuster && <p className="text-sm text-red-600 mt-1">{errors.adjuster}</p>}
-              </div>
             </div>
 
             <div>
@@ -279,16 +239,7 @@ export function ClaimReviewDialog({ claim, trigger }: ClaimReviewDialogProps) {
           </div>
 
           <div className="responsive-stack pt-4 border-t border-slate-200 dark:border-slate-700">
-            <Button variant="outline" onClick={() => setOpen(false)} className="flex-1">Cancel</Button>
-            <Button variant="outline" onClick={handleRequestInfo} className="flex-1">Request Info</Button>
-            <Button variant="outline" onClick={handleReject} className="flex-1 text-red-600 dark:text-red-400 border-red-200 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-900/20">
-              <X className="w-4 h-4 mr-2" />
-              Reject Claim
-            </Button>
-            <Button onClick={handleApprove} className="flex-1 gradient-accent text-white floating-button">
-              <CheckCircle className="w-4 h-4 mr-2" />
-              Approve Claim
-            </Button>
+            <Button variant="outline" onClick={() => setOpen(false)} className="flex-1">Close</Button>
             <Button onClick={handleSaveChanges} className="flex-1 gradient-accent text-white floating-button">
               Save Changes
             </Button>

--- a/dashboard/components/shared/Connect.tsx
+++ b/dashboard/components/shared/Connect.tsx
@@ -1,14 +1,30 @@
+"use client";
+
 import React from "react";
+import { useAccount } from "wagmi";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+const formatAddress = (address?: string) =>
+  address ? `${address.slice(0, 6)}...${address.slice(-4)}` : "";
 
 export function Connect() {
+  const { address, isConnected } = useAccount();
+
+  if (isConnected && address) {
+    return (
+      <Button asChild variant="outline" size="sm" className="floating-button">
+        <Link href="/policyholder/wallet">{formatAddress(address)}</Link>
+      </Button>
+    );
+  }
+
   return (
-    <div>
-     <appkit-button
-        label="Connect"
-        balance="hide"
-        size="sm"
-        loadingLabel="Connecting"
-      />
-    </div>
+    <appkit-button
+      label="Connect"
+      balance="hide"
+      size="sm"
+      loadingLabel="Connecting"
+    />
   );
 }

--- a/dashboard/components/shared/Navbar.tsx
+++ b/dashboard/components/shared/Navbar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "./ThemeToggle";
+import { Connect } from "./Connect";
 import {
   Shield,
   Menu,
@@ -14,7 +15,6 @@ import {
   Home,
   Search,
   FileText,
-  Wallet,
   BarChart3,
   Plus,
   Gift,
@@ -47,7 +47,6 @@ export function Navbar({ role }: NavbarProps) {
       { href: "/policyholder/browse", label: "Browse Policies", icon: Search },
       { href: "/policyholder/coverage", label: "My Coverage", icon: Shield },
       { href: "/policyholder/claims", label: "Claims", icon: FileText },
-      { href: "/policyholder/wallet", label: "Wallet", icon: Wallet },
     ],
     admin: [
       { href: "/admin", label: "Dashboard", icon: BarChart3 },
@@ -160,6 +159,7 @@ export function Navbar({ role }: NavbarProps) {
 
           {/* Right Side Actions */}
           <div className="hidden md:flex items-center space-x-2 lg:space-x-3 xl:space-x-4 flex-shrink-0">
+            {role === "policyholder" && <Connect />}
             <ThemeToggle />
 
             {role && (
@@ -272,6 +272,7 @@ export function Navbar({ role }: NavbarProps) {
         {isOpen && (
           <div className="md:hidden border-t border-white/20 dark:border-slate-700/50 py-4">
             <div className="flex flex-col space-y-4">
+              {role === "policyholder" && <Connect />}
               {navigationLinks.map((link, index) => (
                 <Link
                   key={index}

--- a/dashboard/components/shared/PolicyDetailsDialog.tsx
+++ b/dashboard/components/shared/PolicyDetailsDialog.tsx
@@ -6,11 +6,12 @@ import { Button } from '@/components/ui/button';
 import { Star, Download } from 'lucide-react';
 import { format } from 'date-fns';
 import { cn } from '@/lib/utils';
+import { PolicyControllerFindAllCategory } from '@/api';
 
 export interface Policy {
   id: string | number;
   name: string;
-  category?: string;
+  category: PolicyControllerFindAllCategory;
   provider?: string;
   coverage?: string | number;
   premium?: string | number;
@@ -24,7 +25,6 @@ export interface Policy {
   documents?: { name: string; url: string }[];
   reviews?: { user: string; rating: number; comment: string }[];
   rating?: number;
-  status?: 'active' | 'inactive' | string;
 }
 
 export interface PolicyDetailsDialogProps {
@@ -51,7 +51,6 @@ function formatDate(value?: Date | string) {
 }
 
 export default function PolicyDetailsDialog({ policy, open, onClose }: PolicyDetailsDialogProps) {
-  const statusClass = policy.status === 'active' ? 'status-active' : 'status-warning';
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
@@ -64,11 +63,6 @@ export default function PolicyDetailsDialog({ policy, open, onClose }: PolicyDet
             <DialogTitle className="text-lg font-semibold truncate">
               {policy.name}
             </DialogTitle>
-            {policy.status && (
-              <Badge className={cn('status-badge', statusClass)}>{
-                policy.status.charAt(0).toUpperCase() + policy.status.slice(1)
-              }</Badge>
-            )}
           </div>
         </DialogHeader>
         <div className="space-y-6 mt-4">

--- a/dashboard/components/shared/WalletSectiom.tsx
+++ b/dashboard/components/shared/WalletSectiom.tsx
@@ -3,7 +3,6 @@
 import { useAccount, useBalance } from "wagmi";
 import { formatUnits } from "viem";
 import styled from "styled-components";
-import { Connect } from "./Connect";
 import { useEffect, useState } from "react";
 
 const WalletSection = () => {
@@ -95,7 +94,6 @@ const WalletSection = () => {
               : "Loading..."}
           </p>
         </div>
-        <Connect />
       </div>
     </StyledWrapper>
   );


### PR DESCRIPTION
## Summary
- allow filtering policies by user ID
- add view and edit dialogs to Manage Policies
- simplify Claim Review workflow
- remove approve/reject actions on claims

## Testing
- `npm --prefix backend run lint` *(fails: 8 errors)*
- `npm --prefix dashboard run lint` *(fails to parse many files)*
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_688c77050e9c8320aaad789eb49144f5