### PR TITLE
Add conditional filter logic for policy queries

### DIFF
--- a/dashboard/app/(admin)/admin/policies/page.tsx
+++ b/dashboard/app/(admin)/admin/policies/page.tsx
@@ -54,6 +54,7 @@ import { useToast } from "@/components/shared/ToastProvider";
 import {
   PolicyControllerFindAllCategory,
   CreatePolicyDtoCategory,
+  PolicyControllerFindAllParams,
 } from "@/api";
 
 export default function ManagePolicies() {
@@ -95,16 +96,24 @@ export default function ManagePolicies() {
     claimTypes: [""],
   });
 
+  const hasFilters =
+    filterCategory !== "all" || !!debouncedSearchTerm;
+
+  const filters = hasFilters
+    ? {
+        ...(filterCategory !== "all" && {
+          category: filterCategory as PolicyControllerFindAllCategory,
+        }),
+        ...(debouncedSearchTerm && { search: debouncedSearchTerm }),
+      }
+    : {};
+
   const {
     data: policiesData,
     isLoading,
     error,
   } = usePoliciesQuery({
-    category:
-      filterCategory === "all"
-        ? undefined
-        : (filterCategory as PolicyControllerFindAllCategory),
-    search: debouncedSearchTerm,
+    ...(filters as PolicyControllerFindAllParams),
     page: currentPage,
     limit: itemsPerPage,
     userId: meData?.data?.id,

--- a/dashboard/app/(policyholder)/policyholder/browse/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/browse/page.tsx
@@ -27,6 +27,7 @@ import {
   PolicyControllerFindAllCategory,
   PolicyControllerFindAllSortBy,
   PolicyCategoryCountStatsDto,
+  PolicyControllerFindAllParams,
 } from "@/api";
 
 const ITEMS_PER_PAGE = 6;
@@ -75,16 +76,24 @@ export default function BrowsePolicies() {
 
   const { data: categoryCountsData } = useCategoryCountsQuery();
 
+  const hasFilters =
+    selectedCategory !== "all" || !!debouncedSearchTerm;
+
+  const filters = hasFilters
+    ? {
+        ...(selectedCategory !== "all" && {
+          category: selectedCategory as PolicyControllerFindAllCategory,
+        }),
+        ...(debouncedSearchTerm && { search: debouncedSearchTerm }),
+      }
+    : {};
+
   const {
     data: policiesData,
     isLoading,
     error,
   } = usePoliciesQuery({
-    category:
-      selectedCategory === "all"
-        ? undefined
-        : (selectedCategory as PolicyControllerFindAllCategory),
-    search: debouncedSearchTerm,
+    ...(filters as PolicyControllerFindAllParams),
     page: currentPage,
     limit: ITEMS_PER_PAGE,
     sortBy: sortParams.sortBy,

--- a/dashboard/app/(policyholder)/policyholder/coverage/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/coverage/page.tsx
@@ -30,6 +30,7 @@ import {
   usePolicyholderSummaryQuery,
 } from '@/hooks/useCoverage';
 import { useToast } from '@/components/shared/ToastProvider';
+import type { CoverageControllerFindAllParams } from '@/api';
 
 const ITEMS_PER_PAGE = 5;
 
@@ -89,12 +90,21 @@ export default function MyCoverage() {
   const [filterStatus, setFilterStatus] = useState('all');
   const [sortBy, setSortBy] = useState('newest');
 
+  const hasFilters = filterStatus !== 'all';
+
+  const filters = hasFilters
+    ? {
+        ...(filterStatus !== 'all' && { status: filterStatus }),
+      }
+    : {};
+
   // Fetch coverage data
   const {
     data: coverageResponse,
     isLoading: isLoadingCoverage,
     error: coverageError,
   } = useCoverageListQuery({
+    ...(filters as CoverageControllerFindAllParams),
     limit: 100, // Get all coverage for this user
   });
 


### PR DESCRIPTION
## Summary
- Apply conditional filter building in admin policy management to only send active filters
- Add filter handling for policy browsing to pass category/search selectively
- Support conditional status filtering for coverage list requests

## Testing
- `npm --prefix dashboard run lint` *(fails: Parsing error: The keyword 'import' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_688dae88e99083209086b4a86eb5bead