### PR TITLE
feat: enrich claim responses and admin dashboard stats

### DIFF
--- a/backend/src/api/claim/dto/responses/claim.dto.ts
+++ b/backend/src/api/claim/dto/responses/claim.dto.ts
@@ -18,6 +18,37 @@ export class ClaimDocumentResponseDto {
   signedUrl!: string;
 }
 
+export class PolicyHolderDetailsDto {
+  @ApiProperty()
+  user_id!: string;
+
+  @ApiProperty()
+  date_of_birth!: string;
+
+  @ApiProperty({ required: false })
+  occupation?: string | null;
+
+  @ApiProperty({ required: false })
+  address?: string | null;
+}
+
+export class PolicySummaryDto {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty()
+  provider!: string;
+
+  @ApiProperty()
+  coverage!: number;
+
+  @ApiProperty()
+  premium!: number;
+}
+
 export class ClaimResponseDto {
   @ApiProperty()
   id!: number;
@@ -45,4 +76,10 @@ export class ClaimResponseDto {
 
   @ApiProperty({ type: [ClaimDocumentResponseDto] })
   claim_documents!: ClaimDocumentResponseDto[];
+
+  @ApiProperty({ type: PolicyHolderDetailsDto, required: false })
+  policyholder_details?: PolicyHolderDetailsDto;
+
+  @ApiProperty({ type: PolicySummaryDto, required: false })
+  policy?: PolicySummaryDto;
 }

--- a/backend/src/api/dashboard/dashboard.controller.ts
+++ b/backend/src/api/dashboard/dashboard.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { DashboardService } from './dashboard.service';
+import { AuthGuard } from '../auth/auth.guard';
+import { AuthenticatedRequest } from 'src/supabase/types/express';
+import { ApiBearerAuth } from '@nestjs/swagger';
+import { ApiCommonResponse, CommonResponseDto } from 'src/common/common.dto';
+import { DashboardSummaryDto } from './dto/dashboard-summary.dto';
+
+@Controller('dashboard')
+@ApiBearerAuth('supabase-auth')
+export class DashboardController {
+  constructor(private readonly dashboardService: DashboardService) {}
+
+  @Get()
+  @UseGuards(AuthGuard)
+  @ApiCommonResponse(DashboardSummaryDto, false, 'Get dashboard summary')
+  getSummary(
+    @Req() req: AuthenticatedRequest,
+  ): Promise<CommonResponseDto<DashboardSummaryDto>> {
+    return this.dashboardService.getAdminSummary(req);
+  }
+}

--- a/backend/src/api/dashboard/dashboard.module.ts
+++ b/backend/src/api/dashboard/dashboard.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+
+@Module({
+  controllers: [DashboardController],
+  providers: [DashboardService],
+})
+export class DashboardModule {}

--- a/backend/src/api/dashboard/dashboard.module.ts
+++ b/backend/src/api/dashboard/dashboard.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { DashboardController } from './dashboard.controller';
 import { DashboardService } from './dashboard.service';
+import { SupabaseModule } from 'src/supabase/supabase.module';
 
 @Module({
   controllers: [DashboardController],
   providers: [DashboardService],
+  imports: [SupabaseModule],
 })
 export class DashboardModule {}

--- a/backend/src/api/dashboard/dashboard.service.ts
+++ b/backend/src/api/dashboard/dashboard.service.ts
@@ -26,17 +26,16 @@ export class DashboardService {
       throw new InternalServerErrorException('Failed to count pending claims');
     }
 
-    const { data: salesData, error: salesError } = await supabase.rpc(
-      'count_policy_sales',
-    );
+    const { data: salesData, error: salesError } =
+      await supabase.rpc('count_policy_sales');
     if (salesError) {
       throw new InternalServerErrorException('Failed to fetch policy sales');
     }
 
     const sorted = (salesData || [])
-      .sort((a: any, b: any) => b.sales - a.sales)
+      .sort((a: { sales: number }, b: { sales: number }) => b.sales - a.sales)
       .slice(0, 5);
-    const ids = sorted.map((s: any) => s.policy_id);
+    const ids = sorted.map((s) => s.policy_id);
 
     let topPolicies: TopPolicyDto[] = [];
     if (ids.length) {
@@ -48,13 +47,12 @@ export class DashboardService {
         throw new InternalServerErrorException('Failed to fetch policies');
       }
       topPolicies = sorted.map(
-        (s: any): TopPolicyDto => (
+        (s: { policy_id: number; sales: number }): TopPolicyDto =>
           new TopPolicyDto({
             id: s.policy_id,
             name: policies.find((p) => p.id === s.policy_id)?.name || '',
             sales: s.sales,
-          })
-        ),
+          }),
       );
     }
 

--- a/backend/src/api/dashboard/dashboard.service.ts
+++ b/backend/src/api/dashboard/dashboard.service.ts
@@ -1,0 +1,71 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { AuthenticatedRequest } from 'src/supabase/types/express';
+import { CommonResponseDto } from 'src/common/common.dto';
+import { DashboardSummaryDto, TopPolicyDto } from './dto/dashboard-summary.dto';
+
+@Injectable()
+export class DashboardService {
+  async getAdminSummary(
+    req: AuthenticatedRequest,
+  ): Promise<CommonResponseDto<DashboardSummaryDto>> {
+    const supabase = req.supabase;
+
+    const { count: activeCount, error: activeError } = await supabase
+      .from('policies')
+      .select('id', { head: true, count: 'exact' })
+      .eq('status', 'active');
+    if (activeError) {
+      throw new InternalServerErrorException('Failed to count active policies');
+    }
+
+    const { count: pendingCount, error: pendingError } = await supabase
+      .from('claims')
+      .select('id', { head: true, count: 'exact' })
+      .eq('status', 'pending');
+    if (pendingError) {
+      throw new InternalServerErrorException('Failed to count pending claims');
+    }
+
+    const { data: salesData, error: salesError } = await supabase.rpc(
+      'count_policy_sales',
+    );
+    if (salesError) {
+      throw new InternalServerErrorException('Failed to fetch policy sales');
+    }
+
+    const sorted = (salesData || [])
+      .sort((a: any, b: any) => b.sales - a.sales)
+      .slice(0, 5);
+    const ids = sorted.map((s: any) => s.policy_id);
+
+    let topPolicies: TopPolicyDto[] = [];
+    if (ids.length) {
+      const { data: policies, error: policiesError } = await supabase
+        .from('policies')
+        .select('id, name')
+        .in('id', ids);
+      if (policiesError) {
+        throw new InternalServerErrorException('Failed to fetch policies');
+      }
+      topPolicies = sorted.map(
+        (s: any): TopPolicyDto => (
+          new TopPolicyDto({
+            id: s.policy_id,
+            name: policies.find((p) => p.id === s.policy_id)?.name || '',
+            sales: s.sales,
+          })
+        ),
+      );
+    }
+
+    return new CommonResponseDto<DashboardSummaryDto>({
+      statusCode: 200,
+      message: 'Dashboard summary retrieved successfully',
+      data: new DashboardSummaryDto({
+        activePolicies: activeCount || 0,
+        pendingClaims: pendingCount || 0,
+        topPolicies,
+      }),
+    });
+  }
+}

--- a/backend/src/api/dashboard/dto/dashboard-summary.dto.ts
+++ b/backend/src/api/dashboard/dto/dashboard-summary.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TopPolicyDto {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty()
+  sales!: number;
+
+  constructor(init?: Partial<TopPolicyDto>) {
+    Object.assign(this, init);
+  }
+}
+
+export class DashboardSummaryDto {
+  @ApiProperty()
+  activePolicies!: number;
+
+  @ApiProperty()
+  pendingClaims!: number;
+
+  @ApiProperty({ type: [TopPolicyDto] })
+  topPolicies!: TopPolicyDto[];
+
+  constructor(init?: Partial<DashboardSummaryDto>) {
+    Object.assign(this, init);
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { CoverageModule } from './api/coverage/coverage.module';
 import { PdfClaimExtractorModule } from './api/pdf-claim-extractor/pdf-claim-extractor.module';
 import { ReviewsModule } from './api/reviews/reviews.module';
 import { CompanyModule } from './api/company/company.module';
+import { DashboardModule } from './api/dashboard/dashboard.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { CompanyModule } from './api/company/company.module';
     PdfClaimExtractorModule,
     ReviewsModule,
     CompanyModule,
+    DashboardModule,
   ],
 
   controllers: [AppController],

--- a/backend/swagger-spec.json
+++ b/backend/swagger-spec.json
@@ -1622,6 +1622,43 @@
           "Company"
         ]
       }
+    },
+    "/dashboard": {
+      "get": {
+        "operationId": "DashboardController_getSummary",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Get dashboard summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/CommonResponseDto"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/DashboardSummaryDto"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "supabase-auth": []
+          }
+        ],
+        "tags": [
+          "Dashboard"
+        ]
+      }
     }
   },
   "info": {
@@ -2251,6 +2288,54 @@
           "signedUrl"
         ]
       },
+      "PolicyHolderDetailsDto": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "string"
+          },
+          "date_of_birth": {
+            "type": "string"
+          },
+          "occupation": {
+            "type": "object"
+          },
+          "address": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "user_id",
+          "date_of_birth"
+        ]
+      },
+      "PolicySummaryDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "coverage": {
+            "type": "number"
+          },
+          "premium": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "provider",
+          "coverage",
+          "premium"
+        ]
+      },
       "ClaimResponseDto": {
         "type": "object",
         "properties": {
@@ -2283,6 +2368,12 @@
             "items": {
               "$ref": "#/components/schemas/ClaimDocumentResponseDto"
             }
+          },
+          "policyholder_details": {
+            "$ref": "#/components/schemas/PolicyHolderDetailsDto"
+          },
+          "policy": {
+            "$ref": "#/components/schemas/PolicySummaryDto"
           }
         },
         "required": [
@@ -2810,6 +2901,47 @@
         },
         "required": [
           "rating"
+        ]
+      },
+      "TopPolicyDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "sales": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "sales"
+        ]
+      },
+      "DashboardSummaryDto": {
+        "type": "object",
+        "properties": {
+          "activePolicies": {
+            "type": "number"
+          },
+          "pendingClaims": {
+            "type": "number"
+          },
+          "topPolicies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TopPolicyDto"
+            }
+          }
+        },
+        "required": [
+          "activePolicies",
+          "pendingClaims",
+          "topPolicies"
         ]
       }
     }

--- a/dashboard/app/(admin)/admin/claims/components/ClaimReviewDialog.tsx
+++ b/dashboard/app/(admin)/admin/claims/components/ClaimReviewDialog.tsx
@@ -23,8 +23,24 @@ import { FileText } from "lucide-react";
 import type { ReactNode } from "react";
 import { ClaimResponseDto } from "@/api";
 
+interface ClaimWithDetails extends ClaimResponseDto {
+  policy?: {
+    id: number;
+    name: string;
+    provider: string;
+    coverage: number;
+    premium: number;
+  };
+  policyholder_details?: {
+    user_id: string;
+    date_of_birth: string;
+    occupation?: string | null;
+    address?: string | null;
+  };
+}
+
 interface ClaimReviewDialogProps {
-  claim: ClaimResponseDto;
+  claim: ClaimWithDetails;
   trigger?: ReactNode;
 }
 
@@ -155,6 +171,34 @@ export function ClaimReviewDialog({ claim, trigger }: ClaimReviewDialogProps) {
                     </span>
                   </div>
                 )}
+                {claim.policy && (
+                  <>
+                    <div className="flex justify-between">
+                      <span className="text-slate-600 dark:text-slate-400">
+                        Policy:
+                      </span>
+                      <span className="text-slate-800 dark:text-slate-100">
+                        {claim.policy.name}
+                      </span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-slate-600 dark:text-slate-400">
+                        Coverage:
+                      </span>
+                      <span className="text-slate-800 dark:text-slate-100">
+                        {claim.policy.coverage}
+                      </span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-slate-600 dark:text-slate-400">
+                        Premium:
+                      </span>
+                      <span className="text-slate-800 dark:text-slate-100">
+                        {claim.policy.premium}
+                      </span>
+                    </div>
+                  </>
+                )}
               </div>
             </div>
             <div>
@@ -169,6 +213,36 @@ export function ClaimReviewDialog({ claim, trigger }: ClaimReviewDialogProps) {
                     </span>
                     <span className="text-slate-800 dark:text-slate-100">
                       {claim.submitted_by}
+                    </span>
+                  </div>
+                )}
+                {claim.policyholder_details?.date_of_birth && (
+                  <div className="flex justify-between">
+                    <span className="text-slate-600 dark:text-slate-400">
+                      Date of Birth:
+                    </span>
+                    <span className="text-slate-800 dark:text-slate-100">
+                      {claim.policyholder_details.date_of_birth}
+                    </span>
+                  </div>
+                )}
+                {claim.policyholder_details?.occupation && (
+                  <div className="flex justify-between">
+                    <span className="text-slate-600 dark:text-slate-400">
+                      Occupation:
+                    </span>
+                    <span className="text-slate-800 dark:text-slate-100">
+                      {claim.policyholder_details.occupation}
+                    </span>
+                  </div>
+                )}
+                {claim.policyholder_details?.address && (
+                  <div className="flex justify-between">
+                    <span className="text-slate-600 dark:text-slate-400">
+                      Address:
+                    </span>
+                    <span className="text-slate-800 dark:text-slate-100">
+                      {claim.policyholder_details.address}
                     </span>
                   </div>
                 )}

--- a/dashboard/app/(admin)/admin/page.tsx
+++ b/dashboard/app/(admin)/admin/page.tsx
@@ -5,8 +5,8 @@ import { StatsCard } from "@/components/shared/StatsCard";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import ClaimReviewDialog from "@/app/(admin)/admin/claims/components/ClaimReviewDialog";
-import { useClaimControllerFindAll, useClaimControllerGetStats } from "@/api";
-import { topPolicies } from "@/public/data/admin/dashboardData";
+import { useClaimControllerFindAll } from "@/api";
+import { useAdminDashboardSummary } from "@/hooks/useDashboard";
 import {
   Shield,
   Users,
@@ -26,7 +26,8 @@ export default function AdminDashboard() {
     page: 1,
   });
   const recentClaims = recentClaimsData?.data ?? [];
-  const { data: stats } = useClaimControllerGetStats({ query: {} });
+  const { data: dashboard } = useAdminDashboardSummary();
+  const summary = dashboard?.data;
   return (
     <div className="section-spacing">
       <div className="max-w-7xl mx-auto">
@@ -49,14 +50,14 @@ export default function AdminDashboard() {
         <div className="stats-grid">
           <StatsCard
             title="Active Policies"
-            value="1,247"
-            change="+8.2% from last month"
-            changeType="positive"
+            value={(summary?.activePolicies ?? 0).toString()}
+            change=""
+            changeType="neutral"
             icon={Shield}
           />
           <StatsCard
             title="Pending Claims"
-            value={(stats?.data?.pending ?? 0).toString()}
+            value={(summary?.pendingClaims ?? 0).toString()}
             change=""
             changeType="neutral"
             icon={AlertCircle}
@@ -195,9 +196,9 @@ export default function AdminDashboard() {
               </CardHeader>
               <CardContent>
                 <div className="element-spacing">
-                  {topPolicies.map((policy, index) => (
+                  {(summary?.topPolicies ?? []).map((policy) => (
                     <div
-                      key={index}
+                      key={policy.id}
                       className="flex items-start justify-between"
                     >
                       <div className="flex-1 min-w-0">
@@ -205,13 +206,8 @@ export default function AdminDashboard() {
                           {policy.name}
                         </p>
                         <p className="text-xs text-slate-600 dark:text-slate-400">
-                          {policy.sales} sales • {policy.revenue}
+                          {policy.sales} sales
                         </p>
-                      </div>
-                      <div className="text-right ml-2">
-                        <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
-                          {policy.trend}
-                        </span>
                       </div>
                     </div>
                   ))}

--- a/dashboard/app/(admin)/admin/policies/components/PolicyDetailsDialog.tsx
+++ b/dashboard/app/(admin)/admin/policies/components/PolicyDetailsDialog.tsx
@@ -48,6 +48,7 @@ function formatValue(value?: string | number, opts?: { currency?: boolean }) {
 function formatDate(value?: Date | string) {
   if (!value) return '';
   const date = typeof value === 'string' ? new Date(value) : value;
+  if (isNaN(date.getTime())) return '';
   return format(date, 'PPP');
 }
 

--- a/dashboard/app/(admin)/admin/policies/page.tsx
+++ b/dashboard/app/(admin)/admin/policies/page.tsx
@@ -107,16 +107,20 @@ export default function ManagePolicies() {
       }
     : {};
 
+  const params: PolicyControllerFindAllParams = {
+    ...(filters as PolicyControllerFindAllParams),
+    page: currentPage,
+    limit: itemsPerPage,
+  };
+  if (meData?.data?.id) {
+    params.userId = meData.data.id;
+  }
+
   const {
     data: policiesData,
     isLoading,
     error,
-  } = usePoliciesQuery({
-    ...(filters as PolicyControllerFindAllParams),
-    page: currentPage,
-    limit: itemsPerPage,
-    userId: meData?.data?.id,
-  });
+  } = usePoliciesQuery(params);
 
   useEffect(() => {}, [policiesData]);
 
@@ -136,11 +140,11 @@ export default function ManagePolicies() {
     provider: policy.provider,
     coverage: policy.coverage ? `$${policy.coverage.toLocaleString()}` : "-",
     premium: policy.premium,
-    status: "active",
+    status: policy.status,
     sales: policy.sales,
     revenue: "-",
-    created: "-",
-    lastUpdated: "-",
+    created: undefined,
+    lastUpdated: undefined,
     description:
       typeof policy.description === "string" ? policy.description : "",
     features: policy.claim_types || [],
@@ -177,10 +181,8 @@ export default function ManagePolicies() {
     switch (status) {
       case "active":
         return "status-active";
-      case "draft":
+      case "deactivated":
         return "status-pending";
-      case "inactive":
-        return "bg-slate-100 text-slate-800 dark:bg-slate-700/50 dark:text-slate-300";
       default:
         return "bg-slate-100 text-slate-800 dark:bg-slate-700/50 dark:text-slate-300";
     }
@@ -732,8 +734,8 @@ export default function ManagePolicies() {
                 <TabsTrigger value="active" className="rounded-lg">
                   Active Policies
                 </TabsTrigger>
-                <TabsTrigger value="draft" className="rounded-lg">
-                  Draft Policies
+                <TabsTrigger value="deactivated" className="rounded-lg">
+                  Deactivated Policies
                 </TabsTrigger>
               </TabsList>
 

--- a/dashboard/hooks/useDashboard.ts
+++ b/dashboard/hooks/useDashboard.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { customFetcher } from "@/api/fetch";
+
+export interface DashboardSummary {
+  activePolicies: number;
+  pendingClaims: number;
+  topPolicies: { id: number; name: string; sales: number }[];
+}
+
+export function useAdminDashboardSummary() {
+  return useQuery<{ data: DashboardSummary }>({
+    queryKey: ["admin-dashboard-summary"],
+    queryFn: () =>
+      customFetcher<{ data: DashboardSummary }>({ url: "/dashboard", method: "GET" }),
+  });
+}

--- a/dashboard/public/data/admin/policiesData.ts
+++ b/dashboard/public/data/admin/policiesData.ts
@@ -56,7 +56,7 @@ export const policies = [
       provider: 'MediChain',
       coverage: '$250,000',
       premium: '1.5 ETH/month',
-      status: 'draft',
+      status: 'deactivated',
       sales: 0,
       revenue: '0 ETH',
       created: '2024-12-01',
@@ -248,7 +248,7 @@ export const policies = [
       provider: 'TeleHealth Pro',
       coverage: '$120,000',
       premium: '0.6 ETH/month',
-      status: 'draft',
+      status: 'deactivated',
       sales: 0,
       revenue: '0 ETH',
       created: '2024-11-01',
@@ -296,7 +296,7 @@ export const policies = [
       provider: 'EmergencyMed',
       coverage: '$150,000',
       premium: '0.9 ETH/month',
-      status: 'draft',
+      status: 'deactivated',
       sales: 0,
       revenue: '0 ETH',
       created: '2024-11-15',
@@ -344,8 +344,7 @@ export const policies = [
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'active': return 'status-active';
-      case 'draft': return 'status-pending';
-      case 'inactive': return 'bg-slate-100 text-slate-800 dark:bg-slate-700/50 dark:text-slate-300';
+      case 'deactivated': return 'status-pending';
       default: return 'bg-slate-100 text-slate-800 dark:bg-slate-700/50 dark:text-slate-300';
     }
   };


### PR DESCRIPTION
## Summary
- include policy and policyholder information in claim responses and review dialog
- add admin dashboard summary endpoint and display active policies, pending claims, and top policies
- improve policy management by using deactivated status, skipping undefined userId, and handling invalid dates

## Testing
- `npm test` (backend)
- `npm run lint` (dashboard) *(fails: The keyword 'import' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_688dda0955cc83208da77fcc1a843701