### PR TITLE
feat: enhance policyholder features and dashboard

### DIFF
--- a/backend/src/api/claim/claim.service.ts
+++ b/backend/src/api/claim/claim.service.ts
@@ -199,16 +199,13 @@ export class ClaimService {
           `${claim.user_details?.first_name ?? ''} ${claim.user_details?.last_name ?? ''}`.trim(),
         claim_documents: documents,
         policyholder_details: claim.policyholder_details || undefined,
-        policy: claim.coverage?.policy
-          ? {
-              id: claim.coverage.policy.id,
-              name: claim.coverage.policy.name,
-              provider:
-                claim.coverage.policy.admin_details?.company?.name || '',
-              coverage: claim.coverage.policy.coverage,
-              premium: claim.coverage.policy.premium,
-            }
-          : undefined,
+        policy: {
+          id: claim.coverage?.policy?.id,
+          name: claim.coverage?.policy?.name,
+          coverage: claim.coverage?.policy?.coverage,
+          premium: claim.coverage?.policy?.premium,
+          provider: claim.coverage?.policy?.admin_details?.company?.name,
+        },
       };
     });
 
@@ -278,15 +275,13 @@ export class ClaimService {
         `${data.user_details?.first_name ?? ''} ${data.user_details?.last_name ?? ''}`.trim(),
       claim_documents: enrichedDocuments,
       policyholder_details: data.policyholder_details || undefined,
-      policy: data.coverage?.policy
-        ? {
-            id: data.coverage.policy.id,
-            name: data.coverage.policy.name,
-            provider: data.coverage.policy.admin_details?.company?.name || '',
-            coverage: data.coverage.policy.coverage,
-            premium: data.coverage.policy.premium,
-          }
-        : undefined,
+      policy: {
+        id: data.coverage?.policy?.id || 0,
+        name: data.coverage?.policy?.name || '',
+        provider: data.coverage?.policy?.admin_details?.company?.name || '',
+        coverage: data.coverage?.policy?.coverage || 0,
+        premium: data.coverage?.policy?.premium || 0,
+      },
     };
 
     return new CommonResponseDto({

--- a/backend/src/api/claim/dto/responses/claim.dto.ts
+++ b/backend/src/api/claim/dto/responses/claim.dto.ts
@@ -25,11 +25,11 @@ export class PolicyHolderDetailsDto {
   @ApiProperty()
   date_of_birth!: string;
 
-  @ApiProperty({ required: false })
-  occupation?: string | null;
+  @ApiProperty()
+  occupation!: string;
 
-  @ApiProperty({ required: false })
-  address?: string | null;
+  @ApiProperty()
+  address!: string;
 }
 
 export class PolicySummaryDto {
@@ -77,9 +77,9 @@ export class ClaimResponseDto {
   @ApiProperty({ type: [ClaimDocumentResponseDto] })
   claim_documents!: ClaimDocumentResponseDto[];
 
-  @ApiProperty({ type: PolicyHolderDetailsDto, required: false })
-  policyholder_details?: PolicyHolderDetailsDto;
+  @ApiProperty({ type: PolicyHolderDetailsDto })
+  policyholder_details!: PolicyHolderDetailsDto;
 
-  @ApiProperty({ type: PolicySummaryDto, required: false })
-  policy?: PolicySummaryDto;
+  @ApiProperty({ type: PolicySummaryDto })
+  policy!: PolicySummaryDto;
 }

--- a/backend/src/api/coverage/coverage.controller.ts
+++ b/backend/src/api/coverage/coverage.controller.ts
@@ -75,4 +75,10 @@ export class CoverageController {
   async getPolicyholderSummary(@Req() req: AuthenticatedRequest) {
     return this.coverageService.getPolicyholderSummary(req);
   }
+
+  @Get('policyholder/dashboard')
+  @UseGuards(AuthGuard)
+  async getPolicyholderDashboard(@Req() req: AuthenticatedRequest) {
+    return this.coverageService.getDashboardSummary(req);
+  }
 }

--- a/backend/src/api/coverage/coverage.controller.ts
+++ b/backend/src/api/coverage/coverage.controller.ts
@@ -72,13 +72,7 @@ export class CoverageController {
 
   @Get('policyholder/summary')
   @UseGuards(AuthGuard)
-  async getPolicyholderSummary(@Req() req: AuthenticatedRequest) {
-    return this.coverageService.getPolicyholderSummary(req);
-  }
-
-  @Get('policyholder/dashboard')
-  @UseGuards(AuthGuard)
-  async getPolicyholderDashboard(@Req() req: AuthenticatedRequest) {
-    return this.coverageService.getDashboardSummary(req);
+  async getCoverageStats(@Req() req: AuthenticatedRequest) {
+    return this.coverageService.getCoverageStats(req);
   }
 }

--- a/backend/src/api/coverage/coverage.service.ts
+++ b/backend/src/api/coverage/coverage.service.ts
@@ -297,4 +297,53 @@ export class CoverageService {
       },
     };
   }
+
+  async getDashboardSummary(req: AuthenticatedRequest) {
+    const { data: userData, error: userError } =
+      await req.supabase.auth.getUser();
+
+    if (userError || !userData?.user) {
+      throw new UnauthorizedException('Invalid or expired token');
+    }
+
+    const userId = userData.user.id;
+
+    const { data: coverages, error: coverageError } = await req.supabase
+      .from('coverage')
+      .select('id, status, policies:policy_id (coverage)')
+      .eq('user_id', userId);
+
+    if (coverageError) {
+      throw new InternalServerErrorException('Failed to fetch coverages');
+    }
+
+    const activeCoverage = coverages.filter(
+      (c) => c.status === 'active',
+    ).length;
+    const totalCoverage = coverages.reduce(
+      (sum, c) => sum + (c.policies?.coverage || 0),
+      0,
+    );
+
+    const { data: pendingClaims, error: pendingClaimsError } =
+      await req.supabase
+        .from('claims')
+        .select('id')
+        .eq('submitted_by', userId)
+        .eq('status', 'pending');
+
+    if (pendingClaimsError) {
+      throw new InternalServerErrorException('Failed to fetch pending claims');
+    }
+
+    return {
+      statusCode: 200,
+      message: 'Dashboard summary retrieved successfully',
+      data: {
+        activeCoverage,
+        totalCoverage,
+        pendingClaims: pendingClaims.length,
+      },
+    };
+  }
 }

--- a/backend/src/api/dashboard/dashboard.controller.ts
+++ b/backend/src/api/dashboard/dashboard.controller.ts
@@ -4,7 +4,8 @@ import { AuthGuard } from '../auth/auth.guard';
 import { AuthenticatedRequest } from 'src/supabase/types/express';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { ApiCommonResponse, CommonResponseDto } from 'src/common/common.dto';
-import { DashboardSummaryDto } from './dto/dashboard-summary.dto';
+import { AdminDashoboardDto } from './dto/admin-dashboard.dto';
+import { PolicyholderDashboardDto } from './dto/policyholder-dashboard.dto';
 
 @Controller('dashboard')
 @ApiBearerAuth('supabase-auth')
@@ -13,16 +14,23 @@ export class DashboardController {
 
   @Get()
   @UseGuards(AuthGuard)
-  @ApiCommonResponse(DashboardSummaryDto, false, 'Get dashboard summary')
+  @ApiCommonResponse(AdminDashoboardDto, false, 'Get admin dashboard summary')
   getSummary(
     @Req() req: AuthenticatedRequest,
-  ): Promise<CommonResponseDto<DashboardSummaryDto>> {
+  ): Promise<CommonResponseDto<AdminDashoboardDto>> {
     return this.dashboardService.getAdminSummary(req);
   }
 
   @Get('policyholder')
   @UseGuards(AuthGuard)
-  async getPolicyholderSummary(@Req() req: AuthenticatedRequest) {
+  @ApiCommonResponse(
+    PolicyholderDashboardDto,
+    false,
+    'Get policyholder dashboard summary',
+  )
+  async getPolicyholderSummary(
+    @Req() req: AuthenticatedRequest,
+  ): Promise<CommonResponseDto<PolicyholderDashboardDto>> {
     return this.dashboardService.getPolicyholderSummary(req);
   }
 }

--- a/backend/src/api/dashboard/dashboard.controller.ts
+++ b/backend/src/api/dashboard/dashboard.controller.ts
@@ -19,4 +19,10 @@ export class DashboardController {
   ): Promise<CommonResponseDto<DashboardSummaryDto>> {
     return this.dashboardService.getAdminSummary(req);
   }
+
+  @Get('policyholder')
+  @UseGuards(AuthGuard)
+  async getPolicyholderSummary(@Req() req: AuthenticatedRequest) {
+    return this.dashboardService.getPolicyholderSummary(req);
+  }
 }

--- a/backend/src/api/dashboard/dto/admin-dashboard.dto.ts
+++ b/backend/src/api/dashboard/dto/admin-dashboard.dto.ts
@@ -15,7 +15,7 @@ export class TopPolicyDto {
   }
 }
 
-export class DashboardSummaryDto {
+export class AdminDashoboardDto {
   @ApiProperty()
   activePolicies!: number;
 
@@ -31,7 +31,7 @@ export class DashboardSummaryDto {
   @ApiProperty({ type: [TopPolicyDto] })
   topPolicies!: TopPolicyDto[];
 
-  constructor(init?: Partial<DashboardSummaryDto>) {
+  constructor(init?: Partial<AdminDashoboardDto>) {
     Object.assign(this, init);
   }
 }

--- a/backend/src/api/dashboard/dto/policyholder-dashboard.dto.ts
+++ b/backend/src/api/dashboard/dto/policyholder-dashboard.dto.ts
@@ -1,0 +1,61 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PolicyDetailsDto {
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty()
+  coverage!: number;
+
+  constructor(init?: Partial<PolicyDetailsDto>) {
+    Object.assign(this, init);
+  }
+}
+
+export class ActiveCoverageDto {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  policy_id!: number;
+
+  @ApiProperty()
+  status!: string;
+
+  @ApiProperty()
+  utilization_rate!: number;
+
+  @ApiProperty()
+  start_date!: string;
+
+  @ApiProperty()
+  end_date!: string;
+
+  @ApiProperty()
+  next_payment_date!: string;
+
+  @ApiProperty({ type: PolicyDetailsDto, nullable: true })
+  policy!: PolicyDetailsDto | null;
+
+  constructor(init?: Partial<ActiveCoverageDto>) {
+    Object.assign(this, init);
+  }
+}
+
+export class PolicyholderDashboardDto {
+  @ApiProperty()
+  activeCoverage!: number;
+
+  @ApiProperty()
+  totalCoverage!: number;
+
+  @ApiProperty()
+  pendingClaims!: number;
+
+  @ApiProperty({ type: [ActiveCoverageDto] })
+  activeCoverageObject!: ActiveCoverageDto[];
+
+  constructor(init?: Partial<PolicyholderDashboardDto>) {
+    Object.assign(this, init);
+  }
+}

--- a/backend/src/supabase/types/supabase.types.ts
+++ b/backend/src/supabase/types/supabase.types.ts
@@ -427,21 +427,21 @@ export type Database = {
       };
       policyholder_details: {
         Row: {
-          address: string | null;
+          address: string;
           date_of_birth: string;
-          occupation: string | null;
+          occupation: string;
           user_id: string;
         };
         Insert: {
-          address?: string | null;
+          address: string;
           date_of_birth: string;
-          occupation?: string | null;
+          occupation: string;
           user_id: string;
         };
         Update: {
-          address?: string | null;
+          address?: string;
           date_of_birth?: string;
-          occupation?: string | null;
+          occupation?: string;
           user_id?: string;
         };
         Relationships: [

--- a/backend/swagger-spec.json
+++ b/backend/swagger-spec.json
@@ -1560,6 +1560,25 @@
         ]
       }
     },
+    "/coverage/policyholder/dashboard": {
+      "get": {
+        "operationId": "CoverageController_getPolicyholderDashboard",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "supabase-auth": []
+          }
+        ],
+        "tags": [
+          "Coverage"
+        ]
+      }
+    },
     "/claim-type-extractor": {
       "post": {
         "operationId": "PdfClaimExtractorController_extract",

--- a/backend/swagger-spec.json
+++ b/backend/swagger-spec.json
@@ -1543,7 +1543,7 @@
     },
     "/coverage/policyholder/summary": {
       "get": {
-        "operationId": "CoverageController_getPolicyholderSummary",
+        "operationId": "CoverageController_getCoverageStats",
         "parameters": [],
         "responses": {
           "200": {
@@ -1560,9 +1560,9 @@
         ]
       }
     },
-    "/coverage/policyholder/dashboard": {
+    "/dashboard/policyholder": {
       "get": {
-        "operationId": "CoverageController_getPolicyholderDashboard",
+        "operationId": "DashboardController_getPolicyholderSummary",
         "parameters": [],
         "responses": {
           "200": {
@@ -1575,7 +1575,7 @@
           }
         ],
         "tags": [
-          "Coverage"
+          "Dashboard"
         ]
       }
     },

--- a/backend/swagger-spec.json
+++ b/backend/swagger-spec.json
@@ -1560,25 +1560,6 @@
         ]
       }
     },
-    "/dashboard/policyholder": {
-      "get": {
-        "operationId": "DashboardController_getPolicyholderSummary",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "supabase-auth": []
-          }
-        ],
-        "tags": [
-          "Dashboard"
-        ]
-      }
-    },
     "/claim-type-extractor": {
       "post": {
         "operationId": "PdfClaimExtractorController_extract",
@@ -1685,7 +1666,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Get dashboard summary",
+            "description": "Get admin dashboard summary",
             "content": {
               "application/json": {
                 "schema": {
@@ -1696,7 +1677,44 @@
                     {
                       "properties": {
                         "data": {
-                          "$ref": "#/components/schemas/DashboardSummaryDto"
+                          "$ref": "#/components/schemas/AdminDashoboardDto"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "supabase-auth": []
+          }
+        ],
+        "tags": [
+          "Dashboard"
+        ]
+      }
+    },
+    "/dashboard/policyholder": {
+      "get": {
+        "operationId": "DashboardController_getPolicyholderSummary",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Get policyholder dashboard summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/CommonResponseDto"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/PolicyholderDashboardDto"
                         }
                       }
                     }
@@ -2354,15 +2372,17 @@
             "type": "string"
           },
           "occupation": {
-            "type": "object"
+            "type": "string"
           },
           "address": {
-            "type": "object"
+            "type": "string"
           }
         },
         "required": [
           "user_id",
-          "date_of_birth"
+          "date_of_birth",
+          "occupation",
+          "address"
         ]
       },
       "PolicySummaryDto": {
@@ -2441,7 +2461,9 @@
           "submitted_date",
           "priority",
           "submitted_by",
-          "claim_documents"
+          "claim_documents",
+          "policyholder_details",
+          "policy"
         ]
       },
       "ClaimStatsDto": {
@@ -2996,7 +3018,7 @@
           "sales"
         ]
       },
-      "DashboardSummaryDto": {
+      "AdminDashoboardDto": {
         "type": "object",
         "properties": {
           "activePolicies": {
@@ -3024,6 +3046,91 @@
           "activeUsers",
           "totalRevenue",
           "topPolicies"
+        ]
+      },
+      "PolicyDetailsDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "coverage": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "coverage"
+        ]
+      },
+      "ActiveCoverageDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "policy_id": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string"
+          },
+          "utilization_rate": {
+            "type": "number"
+          },
+          "start_date": {
+            "type": "string"
+          },
+          "end_date": {
+            "type": "string"
+          },
+          "next_payment_date": {
+            "type": "string"
+          },
+          "policy": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PolicyDetailsDto"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "policy_id",
+          "status",
+          "utilization_rate",
+          "start_date",
+          "end_date",
+          "next_payment_date",
+          "policy"
+        ]
+      },
+      "PolicyholderDashboardDto": {
+        "type": "object",
+        "properties": {
+          "activeCoverage": {
+            "type": "number"
+          },
+          "totalCoverage": {
+            "type": "number"
+          },
+          "pendingClaims": {
+            "type": "number"
+          },
+          "activeCoverageObject": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActiveCoverageDto"
+            }
+          }
+        },
+        "required": [
+          "activeCoverage",
+          "totalCoverage",
+          "pendingClaims",
+          "activeCoverageObject"
         ]
       }
     }

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -16,11 +16,9 @@ describe('AppController (e2e)', () => {
   });
 
   it('/ (GET)', async () => {
-    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
     await request(app.getHttpServer())
       .get('/')
       .expect(200)
       .expect('Hello World!');
-    /* eslint-enable @typescript-eslint/no-unsafe-member-access */
   });
 });

--- a/dashboard/api/index.ts
+++ b/dashboard/api/index.ts
@@ -4411,7 +4411,7 @@ export const useCoverageControllerRemove = <
   return useMutation(mutationOptions, queryClient);
 };
 
-export const coverageControllerGetPolicyholderSummary = (
+export const coverageControllerGetCoverageStats = (
   signal?: AbortSignal,
 ) => {
   return customFetcher<void>({
@@ -4421,17 +4421,17 @@ export const coverageControllerGetPolicyholderSummary = (
   });
 };
 
-export const getCoverageControllerGetPolicyholderSummaryQueryKey = () => {
+export const getCoverageControllerGetCoverageStatsQueryKey = () => {
   return [`/coverage/policyholder/summary`] as const;
 };
 
-export const getCoverageControllerGetPolicyholderSummaryQueryOptions = <
-  TData = Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>,
+export const getCoverageControllerGetCoverageStatsQueryOptions = <
+  TData = Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>,
   TError = unknown,
 >(options?: {
   query?: Partial<
     UseQueryOptions<
-      Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>,
+      Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>,
       TError,
       TData
     >
@@ -4441,41 +4441,41 @@ export const getCoverageControllerGetPolicyholderSummaryQueryOptions = <
 
   const queryKey =
     queryOptions?.queryKey ??
-    getCoverageControllerGetPolicyholderSummaryQueryKey();
+    getCoverageControllerGetCoverageStatsQueryKey();
 
   const queryFn: QueryFunction<
-    Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>
-  > = ({ signal }) => coverageControllerGetPolicyholderSummary(signal);
+    Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>
+  > = ({ signal }) => coverageControllerGetCoverageStats(signal);
 
   return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>,
+    Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>,
     TError,
     TData
   > & { queryKey: DataTag<QueryKey, TData, TError> };
 };
 
-export type CoverageControllerGetPolicyholderSummaryQueryResult = NonNullable<
-  Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>
+export type CoverageControllerGetCoverageStatsQueryResult = NonNullable<
+  Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>
 >;
-export type CoverageControllerGetPolicyholderSummaryQueryError = unknown;
+export type CoverageControllerGetCoverageStatsQueryError = unknown;
 
-export function useCoverageControllerGetPolicyholderSummary<
-  TData = Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>,
+export function useCoverageControllerGetCoverageStats<
+  TData = Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>,
   TError = unknown,
 >(
   options: {
     query: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>,
+        Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>,
         TError,
         TData
       >
     > &
       Pick<
         DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>,
+          Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>,
           TError,
-          Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>
+          Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>
         >,
         "initialData"
       >;
@@ -4484,23 +4484,23 @@ export function useCoverageControllerGetPolicyholderSummary<
 ): DefinedUseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData, TError>;
 };
-export function useCoverageControllerGetPolicyholderSummary<
-  TData = Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>,
+export function useCoverageControllerGetCoverageStats<
+  TData = Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>,
   TError = unknown,
 >(
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>,
+        Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>,
         TError,
         TData
       >
     > &
       Pick<
         UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>,
+          Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>,
           TError,
-          Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>
+          Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>
         >,
         "initialData"
       >;
@@ -4509,14 +4509,14 @@ export function useCoverageControllerGetPolicyholderSummary<
 ): UseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData, TError>;
 };
-export function useCoverageControllerGetPolicyholderSummary<
-  TData = Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>,
+export function useCoverageControllerGetCoverageStats<
+  TData = Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>,
   TError = unknown,
 >(
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>,
+        Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>,
         TError,
         TData
       >
@@ -4527,14 +4527,14 @@ export function useCoverageControllerGetPolicyholderSummary<
   queryKey: DataTag<QueryKey, TData, TError>;
 };
 
-export function useCoverageControllerGetPolicyholderSummary<
-  TData = Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>,
+export function useCoverageControllerGetCoverageStats<
+  TData = Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>,
   TError = unknown,
 >(
   options?: {
     query?: Partial<
       UseQueryOptions<
-        Awaited<ReturnType<typeof coverageControllerGetPolicyholderSummary>>,
+        Awaited<ReturnType<typeof coverageControllerGetCoverageStats>>,
         TError,
         TData
       >
@@ -4545,7 +4545,7 @@ export function useCoverageControllerGetPolicyholderSummary<
   queryKey: DataTag<QueryKey, TData, TError>;
 } {
   const queryOptions =
-    getCoverageControllerGetPolicyholderSummaryQueryOptions(options);
+    getCoverageControllerGetCoverageStatsQueryOptions(options);
 
   const query = useQuery(queryOptions, queryClient) as UseQueryResult<
     TData,

--- a/dashboard/app/(admin)/admin/claims/components/ClaimReviewDialog.tsx
+++ b/dashboard/app/(admin)/admin/claims/components/ClaimReviewDialog.tsx
@@ -24,18 +24,18 @@ import type { ReactNode } from "react";
 import { ClaimResponseDto } from "@/api";
 
 interface ClaimWithDetails extends ClaimResponseDto {
-  policy?: {
+  policy: {
     id: number;
     name: string;
     provider: string;
     coverage: number;
     premium: number;
   };
-  policyholder_details?: {
+  policyholder_details: {
     user_id: string;
     date_of_birth: string;
-    occupation?: string | null;
-    address?: string | null;
+    occupation: string;
+    address: string;
   };
 }
 

--- a/dashboard/app/(admin)/admin/claims/page.tsx
+++ b/dashboard/app/(admin)/admin/claims/page.tsx
@@ -254,112 +254,123 @@ export default function ClaimsReview() {
 
         {/* Claims List */}
         <div className="content-spacing mb-8">
-          {paginatedClaims.map((claim) => (
-            <Card key={claim.id} className="glass-card rounded-2xl card-hover">
-              <CardContent className="p-6">
-                <div className="flex items-center justify-between mb-4">
-                  <div className="flex items-center space-x-4">
-                    <div className="w-12 h-12 rounded-xl bg-gradient-to-r from-blue-500 to-teal-500 flex items-center justify-center">
-                      <FileText className="w-6 h-6 text-white" />
+          {isLoading ? (
+            <div className="text-center py-12">
+              <FileText className="w-16 h-16 text-slate-400 mx-auto mb-4 animate-spin" />
+              <h3 className="text-xl font-semibold text-slate-600 dark:text-slate-400 mb-2">
+                Loading claims...
+              </h3>
+            </div>
+          ) : (
+            paginatedClaims.map((claim) => (
+              <Card key={claim.id} className="glass-card rounded-2xl card-hover">
+                <CardContent className="p-6">
+                  <div className="flex items-center justify-between mb-4">
+                    <div className="flex items-center space-x-4">
+                      <div className="w-12 h-12 rounded-xl bg-gradient-to-r from-blue-500 to-teal-500 flex items-center justify-center">
+                        <FileText className="w-6 h-6 text-white" />
+                      </div>
+                      <div>
+                        <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100">
+                          {claim.id}
+                        </h3>
+                        <p className="text-slate-600 dark:text-slate-400">
+                          {claim.type}
+                        </p>
+                      </div>
                     </div>
-                    <div>
-                      <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100">
-                        {claim.id}
-                      </h3>
-                      <p className="text-slate-600 dark:text-slate-400">
-                        {claim.type}
-                      </p>
+                    <div className="flex items-center space-x-3">
+                      <Badge
+                        className={`status-badge ${getPriorityColor(
+                          claim.priority
+                        )}`}
+                      >
+                        {claim.priority.toUpperCase()}
+                      </Badge>
+                      <Badge
+                        className={`status-badge ${getStatusColor(claim.status)}`}
+                      >
+                        {getStatusIcon(claim.status)}
+                        <span className="ml-1 capitalize">
+                          {claim.status.replace("-", " ")}
+                        </span>
+                      </Badge>
                     </div>
-                  </div>
-                  <div className="flex items-center space-x-3">
-                    <Badge
-                      className={`status-badge ${getPriorityColor(
-                        claim.priority
-                      )}`}
-                    >
-                      {claim.priority.toUpperCase()}
-                    </Badge>
-                    <Badge
-                      className={`status-badge ${getStatusColor(claim.status)}`}
-                    >
-                      {getStatusIcon(claim.status)}
-                      <span className="ml-1 capitalize">
-                        {claim.status.replace("-", " ")}
-                      </span>
-                    </Badge>
-                  </div>
-                </div>
-
-                <div className="grid md:grid-cols-4 gap-4 mb-4">
-                  <div className="flex items-center space-x-2">
-                    <DollarSign className="w-4 h-4 text-slate-500 dark:text-slate-400" />
-                    <div>
-                      <p className="text-sm text-slate-600 dark:text-slate-400">
-                        Amount
-                      </p>
-                      <p className="font-medium text-slate-800 dark:text-slate-100">
-                        {claim.amount}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <Calendar className="w-4 h-4 text-slate-500 dark:text-slate-400" />
-                    <div>
-                      <p className="text-sm text-slate-600 dark:text-slate-400">
-                        Submitted
-                      </p>
-                      <p className="font-medium text-slate-800 dark:text-slate-100">
-                        {new Date(claim.submitted_date).toLocaleDateString()}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <FileText className="w-4 h-4 text-slate-500 dark:text-slate-400" />
-                    <div>
-                      <p className="text-sm text-slate-600 dark:text-slate-400">
-                        Type
-                      </p>
-                      <p className="font-medium text-slate-800 dark:text-slate-100">
-                        {claim.type}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-
-                <p className="text-slate-700 dark:text-slate-300 mb-4">
-                  {claim.description}
-                </p>
-
-                <div className="flex items-center justify-between">
-                  <div className="flex space-x-2">
-                    <ClaimReviewDialog
-                      claim={claim}
-                      trigger={
-                        <Button variant="outline" className="floating-button">
-                          <Eye className="w-4 h-4 mr-2" />
-                          Review Details
-                        </Button>
-                      }
-                    />
                   </div>
 
-                  {claim.status === "pending" && null}
-                </div>
-              </CardContent>
-            </Card>
-          ))}
+                  <div className="grid md:grid-cols-4 gap-4 mb-4">
+                    <div className="flex items-center space-x-2">
+                      <DollarSign className="w-4 h-4 text-slate-500 dark:text-slate-400" />
+                      <div>
+                        <p className="text-sm text-slate-600 dark:text-slate-400">
+                          Amount
+                        </p>
+                        <p className="font-medium text-slate-800 dark:text-slate-100">
+                          {claim.amount}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <Calendar className="w-4 h-4 text-slate-500 dark:text-slate-400" />
+                      <div>
+                        <p className="text-sm text-slate-600 dark:text-slate-400">
+                          Submitted
+                        </p>
+                        <p className="font-medium text-slate-800 dark:text-slate-100">
+                          {new Date(claim.submitted_date).toLocaleDateString()}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <FileText className="w-4 h-4 text-slate-500 dark:text-slate-400" />
+                      <div>
+                        <p className="text-sm text-slate-600 dark:text-slate-400">
+                          Type
+                        </p>
+                        <p className="font-medium text-slate-800 dark:text-slate-100">
+                          {claim.type}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <p className="text-slate-700 dark:text-slate-300 mb-4">
+                    {claim.description}
+                  </p>
+
+                  <div className="flex items-center justify-between">
+                    <div className="flex space-x-2">
+                      <ClaimReviewDialog
+                        claim={claim}
+                        trigger={
+                          <Button variant="outline" className="floating-button">
+                            <Eye className="w-4 h-4 mr-2" />
+                            Review Details
+                          </Button>
+                        }
+                      />
+                    </div>
+
+                    {claim.status === "pending" && null}
+                  </div>
+                </CardContent>
+              </Card>
+            ))
+          )}
         </div>
 
         {/* Pagination */}
-        <Pagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPageChange={setCurrentPage}
-          showInfo={true}
-          totalItems={claims.length}
-          itemsPerPage={ITEMS_PER_PAGE}
-          className="mb-8"
-        />
+        {!isLoading && (
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={setCurrentPage}
+            showInfo={true}
+            totalItems={claims.length}
+            itemsPerPage={ITEMS_PER_PAGE}
+            className="mb-8"
+          />
+        )}
 
         {claims.length === 0 && !isLoading && (
           <div className="text-center py-12">

--- a/dashboard/app/(admin)/admin/policies/components/PolicyDetailsDialog.tsx
+++ b/dashboard/app/(admin)/admin/policies/components/PolicyDetailsDialog.tsx
@@ -11,9 +11,8 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Star, Download } from "lucide-react";
-import { format } from "date-fns";
-import { cn } from "@/lib/utils";
 import { PolicyControllerFindAllCategory } from "@/api";
+import { formatDate, formatValue } from '@/utils/formatHelper';
 
 export interface Policy {
   id: string | number;
@@ -22,6 +21,7 @@ export interface Policy {
   provider?: string;
   coverage: number;
   premium: number;
+  popular?: boolean;
   sales?: number | string;
   revenue: number;
   created?: Date | string;
@@ -39,29 +39,6 @@ export interface PolicyDetailsDialogProps {
   policy: Policy;
   open: boolean;
   onClose: () => void;
-}
-
-const currency = new Intl.NumberFormat("ms-MY", {
-  style: "currency",
-  currency: "MYR",
-});
-const numberFormatter = new Intl.NumberFormat("ms-MY");
-
-function formatValue(value?: string | number, opts?: { currency?: boolean }) {
-  if (value === undefined || value === null) return "-";
-  if (typeof value === "number") {
-    return opts?.currency
-      ? currency.format(value)
-      : numberFormatter.format(value);
-  }
-  return value;
-}
-
-function formatDate(value?: Date | string) {
-  if (!value) return "";
-  const date = typeof value === "string" ? new Date(value) : value;
-  if (isNaN(date.getTime())) return "";
-  return format(date, "PPP");
 }
 
 export default function PolicyDetailsDialog({

--- a/dashboard/app/(policyholder)/policyholder/browse/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/browse/page.tsx
@@ -280,120 +280,129 @@ export default function BrowsePolicies() {
 
         {/* Policy Grid */}
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-          {policies.map((policy) => {
-            const categoryInfo = policyCategories.find(
-              (cat) => cat.id === policy.category
-            );
-            return (
-              <Card
-                key={policy.id}
-                className="glass-card rounded-2xl card-hover relative overflow-hidden"
-              >
-                {policy.sales && (
-                  <Badge className="absolute top-4 right-4 bg-gradient-to-r from-emerald-500 to-teal-500 text-white">
-                    Popular
-                  </Badge>
-                )}
-
-                <CardHeader className="pb-4">
-                  <div className="flex items-center mb-3">
-                    <div
-                      className={`w-12 h-12 rounded-xl bg-gradient-to-r ${categoryInfo?.color} flex items-center justify-center mr-3`}
-                    >
-                      {categoryInfo && (
-                        <categoryInfo.icon className="w-6 h-6 text-white" />
-                      )}
-                    </div>
-                    <div className="flex-1">
-                      <CardTitle className="text-lg text-slate-800 dark:text-slate-100">
-                        {policy.name}
-                      </CardTitle>
-                      <p className="text-sm text-slate-600 dark:text-slate-400">
-                        {policy.provider}
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="flex items-center mb-2">
-                    <Star className="w-4 h-4 text-yellow-500 fill-current" />
-                    <span className="text-sm font-medium text-slate-700 dark:text-slate-300 ml-1">
-                      {policy.rating}
-                    </span>
-                  </div>
-                </CardHeader>
-
-                <CardContent className="pt-0">
-                  <p className="text-sm text-slate-600 dark:text-slate-400 mb-4">
-                    {policy.description}
-                  </p>
-
-                  <div className="space-y-3 mb-6">
-                    <div className="flex justify-between">
-                      <span className="text-sm text-slate-600 dark:text-slate-400">
-                        Coverage
-                      </span>
-                      <span className="text-sm font-semibold text-slate-800 dark:text-slate-100">
-                        {policy.coverage}
-                      </span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-sm text-slate-600 dark:text-slate-400">
-                        Premium
-                      </span>
-                      <span className="text-sm font-semibold text-emerald-600 dark:text-emerald-400">
-                        {policy.premium}
-                      </span>
-                    </div>
-                  </div>
-
-                  {policy.features && policy.features.length > 0 && (
-                    <div className="mb-6">
-                      <p className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
-                        Key Features:
-                      </p>
-                      <div className="flex flex-wrap gap-1">
-                        {policy.features.slice(0, 3).map((feature, index) => (
-                          <Badge
-                            key={index}
-                            variant="secondary"
-                            className="text-xs bg-slate-200 dark:bg-slate-600/50 text-slate-700 dark:text-slate-300"
-                          >
-                            {feature}
-                          </Badge>
-                        ))}
-                        {policy.features.length > 3 && (
-                          <Badge
-                            variant="secondary"
-                            className="text-xs bg-slate-200 dark:bg-slate-600/50 text-slate-700 dark:text-slate-300"
-                          >
-                            +{policy.features.length - 3} more
-                          </Badge>
-                        )}
-                      </div>
-                    </div>
+          {isLoading ? (
+            <div className="col-span-full text-center py-12">
+              <Shield className="w-16 h-16 text-slate-400 mx-auto mb-4 animate-spin" />
+              <h3 className="text-xl font-semibold text-slate-600 dark:text-slate-400 mb-2">
+                Loading policies...
+              </h3>
+            </div>
+          ) : (
+            policies.map((policy) => {
+              const categoryInfo = policyCategories.find(
+                (cat) => cat.id === policy.category
+              );
+              return (
+                <Card
+                  key={policy.id}
+                  className="glass-card rounded-2xl card-hover relative overflow-hidden"
+                >
+                  {policy.popular && (
+                    <Badge className="absolute top-4 right-4 bg-gradient-to-r from-emerald-500 to-teal-500 text-white">
+                      Popular
+                    </Badge>
                   )}
 
-                  <div className="flex gap-2">
-                    <Button
-                      variant="outline"
-                      className="flex-1 floating-button"
-                      onClick={() => openDetails(policy)}
-                    >
-                      Details
-                    </Button>
-                    <Link
-                      href={`/policyholder/payment?policy=${policy.id}`}
-                      className="flex-1"
-                    >
-                      <Button className="w-full gradient-accent text-white floating-button">
-                        Buy with Token
+                  <CardHeader className="pb-4">
+                    <div className="flex items-center mb-3">
+                      <div
+                        className={`w-12 h-12 rounded-xl bg-gradient-to-r ${categoryInfo?.color} flex items-center justify-center mr-3`}
+                      >
+                        {categoryInfo && (
+                          <categoryInfo.icon className="w-6 h-6 text-white" />
+                        )}
+                      </div>
+                      <div className="flex-1">
+                        <CardTitle className="text-lg text-slate-800 dark:text-slate-100">
+                          {policy.name}
+                        </CardTitle>
+                        <p className="text-sm text-slate-600 dark:text-slate-400">
+                          {policy.provider}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center mb-2">
+                      <Star className="w-4 h-4 text-yellow-500 fill-current" />
+                      <span className="text-sm font-medium text-slate-700 dark:text-slate-300 ml-1">
+                        {policy.rating}
+                      </span>
+                    </div>
+                  </CardHeader>
+
+                  <CardContent className="pt-0">
+                    <p className="text-sm text-slate-600 dark:text-slate-400 mb-4">
+                      {policy.description}
+                    </p>
+
+                    <div className="space-y-3 mb-6">
+                      <div className="flex justify-between">
+                        <span className="text-sm text-slate-600 dark:text-slate-400">
+                          Coverage
+                        </span>
+                        <span className="text-sm font-semibold text-slate-800 dark:text-slate-100">
+                          {policy.coverage}
+                        </span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-sm text-slate-600 dark:text-slate-400">
+                          Premium
+                        </span>
+                        <span className="text-sm font-semibold text-emerald-600 dark:text-emerald-400">
+                          {policy.premium}
+                        </span>
+                      </div>
+                    </div>
+
+                    {policy.features && policy.features.length > 0 && (
+                      <div className="mb-6">
+                        <p className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                          Key Features:
+                        </p>
+                        <div className="flex flex-wrap gap-1">
+                          {policy.features.slice(0, 3).map((feature, index) => (
+                            <Badge
+                              key={index}
+                              variant="secondary"
+                              className="text-xs bg-slate-200 dark:bg-slate-600/50 text-slate-700 dark:text-slate-300"
+                            >
+                              {feature}
+                            </Badge>
+                          ))}
+                          {policy.features.length > 3 && (
+                            <Badge
+                              variant="secondary"
+                              className="text-xs bg-slate-200 dark:bg-slate-600/50 text-slate-700 dark:text-slate-300"
+                            >
+                              +{policy.features.length - 3} more
+                            </Badge>
+                          )}
+                        </div>
+                      </div>
+                    )}
+
+                    <div className="flex gap-2">
+                      <Button
+                        variant="outline"
+                        className="flex-1 floating-button"
+                        onClick={() => openDetails(policy)}
+                      >
+                        Details
                       </Button>
-                    </Link>
-                  </div>
-                </CardContent>
-              </Card>
-            );
-          })}
+                      <Link
+                        href={`/policyholder/payment?policy=${policy.id}`}
+                        className="flex-1"
+                      >
+                        <Button className="w-full gradient-accent text-white floating-button">
+                          Buy with Token
+                        </Button>
+                      </Link>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })
+          )}
         </div>
 
         {/* Pagination */}

--- a/dashboard/app/(policyholder)/policyholder/browse/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/browse/page.tsx
@@ -29,6 +29,7 @@ import {
   PolicyCategoryCountStatsDto,
   PolicyControllerFindAllParams,
 } from "@/api";
+import { formatValue } from "@/utils/formatHelper";
 
 const ITEMS_PER_PAGE = 6;
 
@@ -120,7 +121,7 @@ export default function BrowsePolicies() {
       rating: policy.rating,
       features: policy.claim_types ?? [],
       popular: policy.popular,
-      revenue : policy.revenue ?? 0,
+      revenue: policy.revenue ?? 0,
       description:
         typeof policy.description === "string" ? policy.description : "",
       sales: policy.sales,
@@ -341,7 +342,9 @@ export default function BrowsePolicies() {
                           Coverage
                         </span>
                         <span className="text-sm font-semibold text-slate-800 dark:text-slate-100">
-                          {policy.coverage}
+                          {formatValue(policy?.coverage, {
+                            currency: typeof policy?.coverage === "number",
+                          })}
                         </span>
                       </div>
                       <div className="flex justify-between">
@@ -349,7 +352,7 @@ export default function BrowsePolicies() {
                           Premium
                         </span>
                         <span className="text-sm font-semibold text-emerald-600 dark:text-emerald-400">
-                          {policy.premium}
+                          {policy.premium} ETH/month
                         </span>
                       </div>
                     </div>

--- a/dashboard/app/(policyholder)/policyholder/coverage/components/CoverageDetailsDialog.tsx
+++ b/dashboard/app/(policyholder)/policyholder/coverage/components/CoverageDetailsDialog.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Calendar, Clock } from "lucide-react";
+
+interface CoveragePolicy {
+  id: string;
+  name: string;
+  provider: string;
+  coverage: string;
+  premium: string;
+  status: string;
+  startDate: string;
+  endDate: string;
+  nextPayment: string;
+  benefits: string[];
+}
+
+interface CoverageDetailsDialogProps {
+  policy: CoveragePolicy;
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function CoverageDetailsDialog({
+  policy,
+  open,
+  onClose,
+}: CoverageDetailsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{policy.name}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 mt-4">
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-slate-600 dark:text-slate-400">Provider</p>
+            <p className="text-sm font-medium text-slate-800 dark:text-slate-100">
+              {policy.provider}
+            </p>
+          </div>
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-slate-600 dark:text-slate-400">Coverage</p>
+            <p className="text-sm font-medium text-slate-800 dark:text-slate-100">
+              {policy.coverage}
+            </p>
+          </div>
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-slate-600 dark:text-slate-400">Premium</p>
+            <p className="text-sm font-medium text-emerald-600 dark:text-emerald-400">
+              {policy.premium}
+            </p>
+          </div>
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-slate-600 dark:text-slate-400">Status</p>
+            <Badge>{policy.status}</Badge>
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-2">
+              <Calendar className="w-4 h-4 text-slate-500 dark:text-slate-400" />
+              <p className="text-sm text-slate-600 dark:text-slate-400">Policy Period</p>
+            </div>
+            <p className="text-sm font-medium text-slate-800 dark:text-slate-100">
+              {new Date(policy.startDate).toLocaleDateString()} - {" "}
+              {new Date(policy.endDate).toLocaleDateString()}
+            </p>
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-2">
+              <Clock className="w-4 h-4 text-slate-500 dark:text-slate-400" />
+              <p className="text-sm text-slate-600 dark:text-slate-400">Next Payment</p>
+            </div>
+            <p className="text-sm font-medium text-slate-800 dark:text-slate-100">
+              {new Date(policy.nextPayment).toLocaleDateString()}
+            </p>
+          </div>
+          {policy.benefits.length > 0 && (
+            <div>
+              <p className="text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                Benefits
+              </p>
+              <div className="flex flex-wrap gap-1">
+                {policy.benefits.map((benefit, idx) => (
+                  <Badge
+                    key={idx}
+                    variant="secondary"
+                    className="text-xs bg-slate-200 dark:bg-slate-600/50 text-slate-700 dark:text-slate-300"
+                  >
+                    {benefit}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+        <DialogFooter className="mt-4">
+          <Button onClick={onClose}>Close</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/dashboard/app/(policyholder)/policyholder/coverage/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/coverage/page.tsx
@@ -24,10 +24,7 @@ import {
   Download,
   Filter,
 } from 'lucide-react';
-import {
-  useCoverageListQuery,
-  usePolicyholderSummaryQuery,
-} from '@/hooks/useCoverage';
+import { useCoverageListQuery, useCoverageStatsQuery } from '@/hooks/useCoverage';
 import { useToast } from '@/components/shared/ToastProvider';
 import type { CoverageControllerFindAllParams } from '@/api';
 import CoverageDetailsDialog from './components/CoverageDetailsDialog';
@@ -114,7 +111,7 @@ export default function MyCoverage() {
     data: summaryResponse,
     isLoading: isLoadingSummary,
     error: summaryError,
-  } = usePolicyholderSummaryQuery();
+  } = useCoverageStatsQuery();
 
   const summaryData = summaryResponse?.data;
 
@@ -280,11 +277,11 @@ export default function MyCoverage() {
                 <Badge className="status-badge status-active">Active</Badge>
               </div>
               <h3 className="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-1">
-                {summaryData?.activePolicyCount ?? 0}
+                {summaryData?.activeCoverage ?? 0}
               </h3>
-              <p className="text-slate-600 dark:text-slate-400">
-                Active Policies
-              </p>
+                <p className="text-slate-600 dark:text-slate-400">
+                  Active Coverage
+                </p>
             </CardContent>
           </Card>
 

--- a/dashboard/app/(policyholder)/policyholder/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/page.tsx
@@ -43,7 +43,7 @@ export default function PolicyholderDashboard() {
         {/* Stats Overview */}
         <div className="stats-grid">
           <StatsCard
-            title="Active Policies"
+            title="Active Coverage"
             value={(summary?.data?.activeCoverage ?? 0).toString()}
             icon={Shield}
           />

--- a/dashboard/app/(policyholder)/policyholder/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/page.tsx
@@ -19,6 +19,7 @@ import {
   policies,
   recentActivity,
 } from "@/public/data/policyholder/dashboardData";
+import { formatValue } from "@/utils/formatHelper";
 
 export default function PolicyholderDashboard() {
   const { data: summary } = usePolicyholderDashboardSummaryQuery();
@@ -49,7 +50,9 @@ export default function PolicyholderDashboard() {
           />
           <StatsCard
             title="Total Coverage"
-            value={`$${(summary?.data?.totalCoverage ?? 0).toLocaleString()}`}
+            value={formatValue(summary?.data?.totalCoverage, {
+              currency: typeof summary?.data?.totalCoverage === "number",
+            })}
             icon={TrendingUp}
           />
           <StatsCard
@@ -82,42 +85,48 @@ export default function PolicyholderDashboard() {
               </CardHeader>
               <CardContent>
                 <div className="element-spacing">
-                  {policies.map((policy, index) => (
-                    <div
-                      key={index}
-                      className="flex items-center justify-between p-4 rounded-xl bg-slate-50/50 dark:bg-slate-700/30 hover:bg-slate-100/50 dark:hover:bg-slate-700/50 transition-colors"
-                    >
-                      <div className="flex items-center space-x-4">
-                        <div className="w-12 h-12 rounded-xl bg-gradient-to-r from-blue-500 to-teal-500 flex items-center justify-center">
-                          <Shield className="w-6 h-6 text-white" />
+                  {summary?.data?.activeCoverageObject.map(
+                    (coverage, index) => (
+                      <div
+                        key={index}
+                        className="flex items-center justify-between p-4 rounded-xl bg-slate-50/50 dark:bg-slate-700/30 hover:bg-slate-100/50 dark:hover:bg-slate-700/50 transition-colors"
+                      >
+                        <div className="flex items-center space-x-4">
+                          <div className="w-12 h-12 rounded-xl bg-gradient-to-r from-blue-500 to-teal-500 flex items-center justify-center">
+                            <Shield className="w-6 h-6 text-white" />
+                          </div>
+                          <div>
+                            <h3 className="font-semibold text-slate-800 dark:text-slate-100">
+                              {coverage.policy?.name}
+                            </h3>
+                            <p className="text-sm text-slate-600 dark:text-slate-400">
+                              Coverage:{" "}
+                              {formatValue(coverage.policy?.coverage, {
+                                currency:
+                                  typeof coverage.policy?.coverage === "number",
+                              })}
+                            </p>
+                          </div>
                         </div>
-                        <div>
-                          <h3 className="font-semibold text-slate-800 dark:text-slate-100">
-                            {policy.name}
-                          </h3>
-                          <p className="text-sm text-slate-600 dark:text-slate-400">
-                            Coverage: {policy.coverage}
+                        <div className="text-right">
+                          <Badge
+                            className={`status-badge ${
+                              coverage.status === "Active"
+                                ? "status-active"
+                                : coverage.status === "Claimed"
+                                  ? "status-info"
+                                  : "status-pending"
+                            }`}
+                          >
+                            {coverage.status}
+                          </Badge>
+                          <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+                            Expires: {coverage.end_date}
                           </p>
                         </div>
                       </div>
-                      <div className="text-right">
-                        <Badge
-                          className={`status-badge ${
-                            policy.status === "Active"
-                              ? "status-active"
-                              : policy.status === "Claimed"
-                              ? "status-info"
-                              : "status-pending"
-                          }`}
-                        >
-                          {policy.status}
-                        </Badge>
-                        <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
-                          Expires: {policy.expires}
-                        </p>
-                      </div>
-                    </div>
-                  ))}
+                    )
+                  )}
                 </div>
               </CardContent>
             </Card>
@@ -179,8 +188,8 @@ export default function PolicyholderDashboard() {
                           activity.status === "completed"
                             ? "bg-emerald-100 dark:bg-emerald-900/30"
                             : activity.status === "pending"
-                            ? "bg-yellow-100 dark:bg-yellow-900/30"
-                            : "bg-blue-100 dark:bg-blue-900/30"
+                              ? "bg-yellow-100 dark:bg-yellow-900/30"
+                              : "bg-blue-100 dark:bg-blue-900/30"
                         }`}
                       >
                         {activity.status === "completed" ? (

--- a/dashboard/app/(policyholder)/policyholder/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/page.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { StatsCard } from "@/components/shared/StatsCard";
+import { usePolicyholderDashboardSummaryQuery } from "@/hooks/useDashboard";
 import {
   Shield,
   Clock,
@@ -20,6 +21,7 @@ import {
 } from "@/public/data/policyholder/dashboardData";
 
 export default function PolicyholderDashboard() {
+  const { data: summary } = usePolicyholderDashboardSummaryQuery();
   return (
     <div className="section-spacing">
       <div className="max-w-7xl mx-auto">
@@ -42,23 +44,17 @@ export default function PolicyholderDashboard() {
         <div className="stats-grid">
           <StatsCard
             title="Active Policies"
-            value="3"
-            change="+1 this month"
-            changeType="positive"
+            value={(summary?.data?.activeCoverage ?? 0).toString()}
             icon={Shield}
           />
           <StatsCard
             title="Total Coverage"
-            value="$175,000"
-            change="+$25,000"
-            changeType="positive"
+            value={`$${(summary?.data?.totalCoverage ?? 0).toLocaleString()}`}
             icon={TrendingUp}
           />
           <StatsCard
             title="Pending Claims"
-            value="1"
-            change="Processing"
-            changeType="neutral"
+            value={(summary?.data?.pendingClaims ?? 0).toString()}
             icon={Clock}
           />
           <StatsCard

--- a/dashboard/app/(policyholder)/policyholder/profile/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/profile/page.tsx
@@ -29,8 +29,8 @@ import {
 import { useMeQuery } from "@/hooks/useAuth";
 import { useUpdateUserMutation } from "@/hooks/useUsers";
 import { useToast } from "@/components/shared/ToastProvider";
-import ConfirmationDialog from "@/app/(admin)/admin/policies/components/ConfirmationDialog";
 import { ProfileResponseDto } from "@/api";
+import ConfirmationDialog from '@/components/shared/ConfirmationDialog';
 
 export default function Profile() {
   const [isEditing, setIsEditing] = useState(false);

--- a/dashboard/components/shared/Navbar.tsx
+++ b/dashboard/components/shared/Navbar.tsx
@@ -25,6 +25,7 @@ import {
   AlertTriangle,
   Users,
   ChevronDown,
+  Wallet,
 } from "lucide-react";
 import useAuth from "@/hooks/useAuth";
 import { useToast } from "./ToastProvider";
@@ -198,6 +199,16 @@ export function Navbar({ role }: NavbarProps) {
                         >
                           <User className="w-4 h-4 mr-3" />
                           Profile
+                        </Link>
+                      )}
+                      {pathname.startsWith("/policyholder") && (
+                        <Link
+                          href="/policyholder/wallet"
+                          className="flex items-center px-4 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100/50 dark:hover:bg-slate-700/50 transition-colors"
+                          onClick={() => setIsUserMenuOpen(false)}
+                        >
+                          <Wallet className="w-4 h-4 mr-3" />
+                          Wallet
                         </Link>
                       )}
                       <Link

--- a/dashboard/hooks/useCoverage.ts
+++ b/dashboard/hooks/useCoverage.ts
@@ -4,7 +4,7 @@ import {
   useCoverageControllerCreate,
   useCoverageControllerUpdate,
   useCoverageControllerRemove,
-  useCoverageControllerGetPolicyholderSummary,
+  useCoverageControllerGetCoverageStats,
   type CoverageControllerFindAllParams,
   type CreateCoverageDto,
   type UpdateCoverageDto,
@@ -55,8 +55,8 @@ export function useRemoveCoverageMutation() {
   };
 }
 
-export function usePolicyholderSummaryQuery() {
-  const query = useCoverageControllerGetPolicyholderSummary();
+export function useCoverageStatsQuery() {
+  const query = useCoverageControllerGetCoverageStats();
   return {
     ...query,
     error: parseError(query.error),

--- a/dashboard/hooks/useDashboard.ts
+++ b/dashboard/hooks/useDashboard.ts
@@ -1,9 +1,35 @@
-import { useDashboardControllerGetSummary } from '@/api';
+import { useDashboardControllerGetSummary, type CommonResponseDto } from '@/api';
+import { customFetcher } from '@/api/fetch';
+import { useQuery } from '@tanstack/react-query';
 import { parseError } from '@/utils/parseError';
 
+interface PolicyholderDashboardData {
+  activeCoverage: number;
+  totalCoverage: number;
+  pendingClaims: number;
+}
 
 export function useAdminDashboardSummaryQuery() {
   const query = useDashboardControllerGetSummary();
+  return {
+    ...query,
+    error: parseError(query.error),
+  };
+}
+
+export function usePolicyholderDashboardSummaryQuery() {
+  const query = useQuery<
+    CommonResponseDto & { data: PolicyholderDashboardData }
+  >({
+    queryKey: ['policyholder-dashboard'],
+    queryFn: ({ signal }) =>
+      customFetcher({
+        url: '/coverage/policyholder/dashboard',
+        method: 'GET',
+        signal,
+      }),
+  });
+
   return {
     ...query,
     error: parseError(query.error),

--- a/dashboard/hooks/useDashboard.ts
+++ b/dashboard/hooks/useDashboard.ts
@@ -1,4 +1,4 @@
-import { useDashboardControllerGetSummary, type CommonResponseDto } from '@/api';
+import { useDashboardControllerGetPolicyholderSummary, useDashboardControllerGetSummary, type CommonResponseDto } from '@/api';
 import { customFetcher } from '@/api/fetch';
 import { useQuery } from '@tanstack/react-query';
 import { parseError } from '@/utils/parseError';
@@ -18,18 +18,7 @@ export function useAdminDashboardSummaryQuery() {
 }
 
 export function usePolicyholderDashboardSummaryQuery() {
-  const query = useQuery<
-    CommonResponseDto & { data: PolicyholderDashboardData }
-  >({
-    queryKey: ['policyholder-dashboard'],
-    queryFn: ({ signal }) =>
-      customFetcher({
-        url: '/dashboard/policyholder',
-        method: 'GET',
-        signal,
-      }),
-  });
-
+const query = useDashboardControllerGetPolicyholderSummary();
   return {
     ...query,
     error: parseError(query.error),

--- a/dashboard/hooks/useDashboard.ts
+++ b/dashboard/hooks/useDashboard.ts
@@ -24,7 +24,7 @@ export function usePolicyholderDashboardSummaryQuery() {
     queryKey: ['policyholder-dashboard'],
     queryFn: ({ signal }) =>
       customFetcher({
-        url: '/coverage/policyholder/dashboard',
+        url: '/dashboard/policyholder',
         method: 'GET',
         signal,
       }),

--- a/dashboard/utils/formatHelper.ts
+++ b/dashboard/utils/formatHelper.ts
@@ -1,0 +1,28 @@
+import { format } from "date-fns";
+
+const currency = new Intl.NumberFormat("ms-MY", {
+  style: "currency",
+  currency: "MYR",
+  maximumFractionDigits:0
+});
+const numberFormatter = new Intl.NumberFormat("ms-MY");
+
+export function formatValue(
+  value?: string | number,
+  opts?: { currency?: boolean }
+) {
+  if (value === undefined || value === null) return "-";
+  if (typeof value === "number") {
+    return opts?.currency
+      ? currency.format(value)
+      : numberFormatter.format(value);
+  }
+  return value;
+}
+
+export function formatDate(value?: Date | string) {
+  if (!value) return "";
+  const date = typeof value === "string" ? new Date(value) : value;
+  if (isNaN(date.getTime())) return "";
+  return format(date, "PPP");
+}


### PR DESCRIPTION
## Summary
- fix popular badge and add loading state on policy browse
- show loading indicator for admin claims list
- use policyholder summary with approval rate and details dialog on coverage
- add policyholder dashboard summary endpoint and hook

## Testing
- `npm run lint` (backend)
- `npm test` (backend)
- `npm run lint` (dashboard) *(fails: The keyword 'import' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_688e58a30f348320bfcf99bbddf59cc1