### PR TITLE
feat: load policy and add flexible payments

### DIFF
--- a/backend/src/api/dashboard/dashboard.service.ts
+++ b/backend/src/api/dashboard/dashboard.service.ts
@@ -151,7 +151,7 @@ export class DashboardService {
       throw new InternalServerErrorException('Failed to fetch pending claims');
     }
 
-    return {
+    return new CommonResponseDto<PolicyholderDashboardDto>({
       statusCode: 200,
       message: 'Policyholder dashboard summary retrieved successfully',
       data: new PolicyholderDashboardDto({
@@ -162,6 +162,6 @@ export class DashboardService {
           (c) => new ActiveCoverageDto(c),
         ),
       }),
-    };
+    });
   }
 }

--- a/backend/src/api/payment/dto/requests/create-intent.dto.ts
+++ b/backend/src/api/payment/dto/requests/create-intent.dto.ts
@@ -1,0 +1,4 @@
+export class CreatePaymentIntentDto {
+  amount: number;
+  currency: string;
+}

--- a/backend/src/api/payment/dto/requests/create-intent.dto.ts
+++ b/backend/src/api/payment/dto/requests/create-intent.dto.ts
@@ -1,4 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
 export class CreatePaymentIntentDto {
-  amount: number;
-  currency: string;
+  @ApiProperty()
+  @IsNotEmpty({ message: 'Amount is required' })
+  @IsNumber({}, { message: 'Amount must be a number' })
+  amount!: number;
+
+  @ApiProperty()
+  @IsNotEmpty({ message: 'Currency is required' })
+  @IsString({ message: 'Currency must be a string' })
+  currency!: string;
 }

--- a/backend/src/api/payment/dto/responses/payment-intent.dto.ts
+++ b/backend/src/api/payment/dto/responses/payment-intent.dto.ts
@@ -1,0 +1,3 @@
+export class PaymentIntentResponseDto {
+  clientSecret: string;
+}

--- a/backend/src/api/payment/dto/responses/payment-intent.dto.ts
+++ b/backend/src/api/payment/dto/responses/payment-intent.dto.ts
@@ -1,3 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class PaymentIntentResponseDto {
-  clientSecret: string;
+  @ApiProperty()
+  clientSecret!: string;
 }

--- a/backend/src/api/payment/payment.controller.ts
+++ b/backend/src/api/payment/payment.controller.ts
@@ -15,13 +15,9 @@ export class PaymentController {
   async createIntent(
     @Body() body: CreatePaymentIntentDto,
   ): Promise<CommonResponseDto<PaymentIntentResponseDto>> {
-    const clientSecret = await this.paymentService.createPaymentIntent(
+    return await this.paymentService.createPaymentIntent(
       body.amount,
       body.currency,
     );
-    return {
-      message: 'Payment intent created',
-      data: { clientSecret },
-    };
   }
 }

--- a/backend/src/api/payment/payment.controller.ts
+++ b/backend/src/api/payment/payment.controller.ts
@@ -1,0 +1,27 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { ApiCommonResponse, CommonResponseDto } from 'src/common/common.dto';
+import { PaymentService } from './payment.service';
+import { CreatePaymentIntentDto } from './dto/requests/create-intent.dto';
+import { PaymentIntentResponseDto } from './dto/responses/payment-intent.dto';
+
+@ApiTags('Payments')
+@Controller('payments')
+export class PaymentController {
+  constructor(private readonly paymentService: PaymentService) {}
+
+  @Post('intent')
+  @ApiCommonResponse(PaymentIntentResponseDto, false, 'Create payment intent')
+  async createIntent(
+    @Body() body: CreatePaymentIntentDto,
+  ): Promise<CommonResponseDto<PaymentIntentResponseDto>> {
+    const clientSecret = await this.paymentService.createPaymentIntent(
+      body.amount,
+      body.currency,
+    );
+    return {
+      message: 'Payment intent created',
+      data: { clientSecret },
+    };
+  }
+}

--- a/backend/src/api/payment/payment.module.ts
+++ b/backend/src/api/payment/payment.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { PaymentController } from './payment.controller';
+import { PaymentService } from './payment.service';
+
+@Module({
+  controllers: [PaymentController],
+  providers: [PaymentService],
+})
+export class PaymentModule {}

--- a/backend/src/api/payment/payment.service.ts
+++ b/backend/src/api/payment/payment.service.ts
@@ -1,11 +1,10 @@
 import { Injectable } from '@nestjs/common';
+import { CommonResponseDto } from 'src/common/common.dto';
+import { PaymentIntentResponseDto } from './dto/responses/payment-intent.dto';
 
 @Injectable()
 export class PaymentService {
-  async createPaymentIntent(
-    amount: number,
-    currency: string,
-  ): Promise<string | null> {
+  async createPaymentIntent(amount: number, currency: string) {
     const body = new URLSearchParams();
     body.append('amount', Math.round(amount * 100).toString());
     body.append('currency', currency);
@@ -20,7 +19,11 @@ export class PaymentService {
       body,
     });
 
-    const data = (await response.json()) as { client_secret?: string };
-    return data.client_secret ?? null;
+    const data = (await response.json()) as { client_secret: string };
+    return new CommonResponseDto<PaymentIntentResponseDto>({
+      statusCode: 200,
+      message: 'Payment intent created successfully',
+      data: { clientSecret: data.client_secret },
+    });
   }
 }

--- a/backend/src/api/payment/payment.service.ts
+++ b/backend/src/api/payment/payment.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PaymentService {
+  async createPaymentIntent(
+    amount: number,
+    currency: string,
+  ): Promise<string | null> {
+    const body = new URLSearchParams();
+    body.append('amount', Math.round(amount * 100).toString());
+    body.append('currency', currency);
+    body.append('payment_method_types[]', 'card');
+
+    const response = await fetch('https://api.stripe.com/v1/payment_intents', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.STRIPE_SECRET_KEY ?? ''}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body,
+    });
+
+    const data = (await response.json()) as { client_secret?: string };
+    return data.client_secret ?? null;
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { PdfClaimExtractorModule } from './api/pdf-claim-extractor/pdf-claim-ext
 import { ReviewsModule } from './api/reviews/reviews.module';
 import { CompanyModule } from './api/company/company.module';
 import { DashboardModule } from './api/dashboard/dashboard.module';
+import { PaymentModule } from './api/payment/payment.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { DashboardModule } from './api/dashboard/dashboard.module';
     ReviewsModule,
     CompanyModule,
     DashboardModule,
+    PaymentModule,
   ],
 
   controllers: [AppController],

--- a/backend/swagger-spec.json
+++ b/backend/swagger-spec.json
@@ -1733,6 +1733,48 @@
           "Dashboard"
         ]
       }
+    },
+    "/payments/intent": {
+      "post": {
+        "operationId": "PaymentController_createIntent",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePaymentIntentDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Create payment intent",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/CommonResponseDto"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/PaymentIntentResponseDto"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Payments"
+        ]
+      }
     }
   },
   "info": {
@@ -3131,6 +3173,32 @@
           "totalCoverage",
           "pendingClaims",
           "activeCoverageObject"
+        ]
+      },
+      "PaymentIntentResponseDto": {
+        "type": "object",
+        "properties": {
+          "clientSecret": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "clientSecret"
+        ]
+      },
+      "CreatePaymentIntentDto": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "amount",
+          "currency"
         ]
       }
     }

--- a/dashboard/api/index.ts
+++ b/dashboard/api/index.ts
@@ -619,6 +619,15 @@ export interface PolicyholderDashboardDto {
   activeCoverageObject: ActiveCoverageDto[];
 }
 
+export interface PaymentIntentResponseDto {
+  clientSecret: string;
+}
+
+export interface CreatePaymentIntentDto {
+  amount: number;
+  currency: string;
+}
+
 export type AuthControllerLogin200AllOf = {
   data?: LoginResponseDto;
 };
@@ -956,6 +965,13 @@ export type DashboardControllerGetPolicyholderSummary200AllOf = {
 
 export type DashboardControllerGetPolicyholderSummary200 = CommonResponseDto &
   DashboardControllerGetPolicyholderSummary200AllOf;
+
+export type PaymentControllerCreateIntent200AllOf = {
+  data?: PaymentIntentResponseDto;
+};
+
+export type PaymentControllerCreateIntent200 = CommonResponseDto &
+  PaymentControllerCreateIntent200AllOf;
 
 export const authControllerLogin = (
   loginDto: LoginDto,
@@ -5127,3 +5143,84 @@ export function useDashboardControllerGetPolicyholderSummary<
 
   return query;
 }
+
+export const paymentControllerCreateIntent = (
+  createPaymentIntentDto: CreatePaymentIntentDto,
+  signal?: AbortSignal,
+) => {
+  return customFetcher<PaymentControllerCreateIntent200>({
+    url: `/payments/intent`,
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    data: createPaymentIntentDto,
+    signal,
+  });
+};
+
+export const getPaymentControllerCreateIntentMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof paymentControllerCreateIntent>>,
+    TError,
+    { data: CreatePaymentIntentDto },
+    TContext
+  >;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof paymentControllerCreateIntent>>,
+  TError,
+  { data: CreatePaymentIntentDto },
+  TContext
+> => {
+  const mutationKey = ["paymentControllerCreateIntent"];
+  const { mutation: mutationOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey } };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof paymentControllerCreateIntent>>,
+    { data: CreatePaymentIntentDto }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return paymentControllerCreateIntent(data);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type PaymentControllerCreateIntentMutationResult = NonNullable<
+  Awaited<ReturnType<typeof paymentControllerCreateIntent>>
+>;
+export type PaymentControllerCreateIntentMutationBody = CreatePaymentIntentDto;
+export type PaymentControllerCreateIntentMutationError = unknown;
+
+export const usePaymentControllerCreateIntent = <
+  TError = unknown,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof paymentControllerCreateIntent>>,
+      TError,
+      { data: CreatePaymentIntentDto },
+      TContext
+    >;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof paymentControllerCreateIntent>>,
+  TError,
+  { data: CreatePaymentIntentDto },
+  TContext
+> => {
+  const mutationOptions =
+    getPaymentControllerCreateIntentMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};

--- a/dashboard/app/(policyholder)/policyholder/payment/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/payment/page.tsx
@@ -1,11 +1,11 @@
-'use client';
+"use client";
 
-import { useState, useEffect, useMemo } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Progress } from '@/components/ui/progress';
+import { useState, useEffect, useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
 import {
   Shield,
   ArrowLeft,
@@ -24,45 +24,45 @@ import {
   Heart,
   Plane,
   Sprout,
-} from 'lucide-react';
-import Link from 'next/link';
-import { useCreateCoverageMutation } from '@/hooks/useCoverage';
-import { usePolicyQuery } from '@/hooks/usePolicies';
-import { useToast } from '@/components/shared/ToastProvider';
+} from "lucide-react";
+import Link from "next/link";
+import { useCreateCoverageMutation } from "@/hooks/useCoverage";
+import { usePolicyQuery } from "@/hooks/usePolicies";
+import { useToast } from "@/components/shared/ToastProvider";
 
 export default function PaymentSummary() {
   const router = useRouter();
   const { printMessage } = useToast();
   const [currentStep] = useState(2);
-  const [tokenAmount, setTokenAmount] = useState('');
+  const [tokenAmount, setTokenAmount] = useState("");
   const [showTokenDetails, setShowTokenDetails] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
-  const [paymentMethod, setPaymentMethod] = useState('ETH');
+  const [paymentMethod, setPaymentMethod] = useState("ETH");
 
   // Coverage creation mutation
   const { createCoverage } = useCreateCoverageMutation();
 
   const searchParams = useSearchParams();
-  const policyId = searchParams.get('policy') ?? '';
+  const policyId = searchParams.get("policy") ?? "";
   const { data: policy } = usePolicyQuery(policyId);
 
   const policyData = useMemo(() => {
-    if (!policy) return null;
+    if (!policy?.data) return null;
     return {
-      id: policy.id,
-      name: policy.name,
-      category: policy.category,
-      provider: policy.provider,
-      coverage: `$${policy.coverage.toLocaleString()}`,
-      premium: `${policy.premium} ETH/month`,
-      rating: policy.rating,
-      features: policy.claim_types ?? [],
-      description: String(policy.description ?? ''),
-      duration: `${policy.duration_days} days`,
-      basePrice: policy.premium,
+      id: policy.data.id,
+      name: policy.data.name,
+      category: policy.data.category,
+      provider: policy.data.provider,
+      coverage: `$${policy.data.coverage.toLocaleString()}`,
+      premium: `${policy.data.premium} ETH/month`,
+      rating: policy.data.rating,
+      features: policy.data.claim_types ?? [],
+      description: String(policy.data.description ?? ""),
+      duration: `${policy.data.duration_days} days`,
+      basePrice: policy.data.premium,
       discount: 0,
       fees: 0,
-      total: policy.premium,
+      total: policy.data.premium,
     };
   }, [policy]);
 
@@ -74,11 +74,11 @@ export default function PaymentSummary() {
 
   const getCategoryIcon = (category: string) => {
     switch (category) {
-      case 'health':
+      case "health":
         return Heart;
-      case 'travel':
+      case "travel":
         return Plane;
-      case 'crop':
+      case "crop":
         return Sprout;
       default:
         return Shield;
@@ -87,14 +87,14 @@ export default function PaymentSummary() {
 
   const getCategoryColor = (category: string) => {
     switch (category) {
-      case 'health':
-        return 'from-red-500 to-pink-500';
-      case 'travel':
-        return 'from-blue-500 to-cyan-500';
-      case 'crop':
-        return 'from-green-500 to-emerald-500';
+      case "health":
+        return "from-red-500 to-pink-500";
+      case "travel":
+        return "from-blue-500 to-cyan-500";
+      case "crop":
+        return "from-green-500 to-emerald-500";
       default:
-        return 'from-slate-500 to-slate-600';
+        return "from-slate-500 to-slate-600";
     }
   };
 
@@ -114,23 +114,23 @@ export default function PaymentSummary() {
 
       const coverageData = {
         policy_id: policyData.id,
-        status: 'active' as const,
+        status: "active" as const,
         utilization_rate: 0,
-        start_date: startDate.toISOString().split('T')[0],
-        end_date: endDate.toISOString().split('T')[0],
-        next_payment_date: nextPaymentDate.toISOString().split('T')[0],
+        start_date: startDate.toISOString().split("T")[0],
+        end_date: endDate.toISOString().split("T")[0],
+        next_payment_date: nextPaymentDate.toISOString().split("T")[0],
       };
 
       await createCoverage(coverageData);
 
       await new Promise((resolve) => setTimeout(resolve, 2000));
 
-      printMessage('Payment successful! Coverage created.', 'success');
+      printMessage("Payment successful! Coverage created.", "success");
 
-      router.push('/policyholder/payment/confirmation');
+      router.push("/policyholder/payment/confirmation");
     } catch (error) {
-      console.error('Payment failed:', error);
-      printMessage('Payment failed. Please try again.', 'error');
+      console.error("Payment failed:", error);
+      printMessage("Payment failed. Please try again.", "error");
     } finally {
       setIsProcessing(false);
     }
@@ -139,28 +139,28 @@ export default function PaymentSummary() {
   const handleStripePayment = async () => {
     setIsProcessing(true);
     try {
-      const response = await fetch('http://localhost:3000/payments/intent', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ amount: policyData.total, currency: 'usd' }),
+      const response = await fetch("http://localhost:3000/payments/intent", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ amount: policyData.total, currency: "usd" }),
       });
       const data = await response.json();
       if (data?.data?.clientSecret) {
-        printMessage('Stripe payment initialized', 'success');
-        router.push('/policyholder/payment/confirmation');
+        printMessage("Stripe payment initialized", "success");
+        router.push("/policyholder/payment/confirmation");
       } else {
-        printMessage('Payment failed. Please try again.', 'error');
+        printMessage("Payment failed. Please try again.", "error");
       }
     } catch (error) {
-      console.error('Stripe payment failed:', error);
-      printMessage('Payment failed. Please try again.', 'error');
+      console.error("Stripe payment failed:", error);
+      printMessage("Payment failed. Please try again.", "error");
     } finally {
       setIsProcessing(false);
     }
   };
 
   const handlePayment = async () => {
-    if (paymentMethod === 'STRIPE') {
+    if (paymentMethod === "STRIPE") {
       await handleStripePayment();
       return;
     }
@@ -168,9 +168,9 @@ export default function PaymentSummary() {
   };
 
   const steps = [
-    { id: 1, name: 'Policy Selection', status: 'completed' },
-    { id: 2, name: 'Payment Details', status: 'current' },
-    { id: 3, name: 'Confirmation', status: 'pending' },
+    { id: 1, name: "Policy Selection", status: "completed" },
+    { id: 2, name: "Payment Details", status: "current" },
+    { id: 3, name: "Confirmation", status: "pending" },
   ];
 
   const CategoryIcon = getCategoryIcon(policyData.category);
@@ -206,14 +206,14 @@ export default function PaymentSummary() {
                 <div key={step.id} className="flex items-center">
                   <div
                     className={`flex items-center justify-center w-10 h-10 rounded-full ${
-                      step.status === 'completed'
-                        ? 'bg-emerald-500 text-white'
-                        : step.status === 'current'
-                          ? 'bg-blue-500 text-white'
-                          : 'bg-slate-200 dark:bg-slate-700 text-slate-500 dark:text-slate-400'
+                      step.status === "completed"
+                        ? "bg-emerald-500 text-white"
+                        : step.status === "current"
+                          ? "bg-blue-500 text-white"
+                          : "bg-slate-200 dark:bg-slate-700 text-slate-500 dark:text-slate-400"
                     }`}
                   >
-                    {step.status === 'completed' ? (
+                    {step.status === "completed" ? (
                       <CheckCircle className="w-5 h-5" />
                     ) : (
                       <span className="text-sm font-medium">{step.id}</span>
@@ -221,11 +221,11 @@ export default function PaymentSummary() {
                   </div>
                   <span
                     className={`ml-3 text-sm font-medium ${
-                      step.status === 'current'
-                        ? 'text-blue-600 dark:text-blue-400'
-                        : step.status === 'completed'
-                          ? 'text-emerald-600 dark:text-emerald-400'
-                          : 'text-slate-500 dark:text-slate-400'
+                      step.status === "current"
+                        ? "text-blue-600 dark:text-blue-400"
+                        : step.status === "completed"
+                          ? "text-emerald-600 dark:text-emerald-400"
+                          : "text-slate-500 dark:text-slate-400"
                     }`}
                   >
                     {step.name}
@@ -233,9 +233,9 @@ export default function PaymentSummary() {
                   {index < steps.length - 1 && (
                     <div
                       className={`w-16 h-1 mx-4 ${
-                        step.status === 'completed'
-                          ? 'bg-emerald-500'
-                          : 'bg-slate-200 dark:bg-slate-700'
+                        step.status === "completed"
+                          ? "bg-emerald-500"
+                          : "bg-slate-200 dark:bg-slate-700"
                       }`}
                     />
                   )}
@@ -365,14 +365,14 @@ export default function PaymentSummary() {
                     Payment Method
                   </h3>
                   <div className="grid grid-cols-4 gap-4">
-                    {['ETH', 'USDC', 'DAI', 'STRIPE'].map((method) => (
+                    {["ETH", "USDC", "DAI", "STRIPE"].map((method) => (
                       <button
                         key={method}
                         onClick={() => setPaymentMethod(method)}
                         className={`p-4 rounded-xl border-2 transition-all duration-200 ${
                           paymentMethod === method
-                            ? 'border-emerald-500 bg-emerald-50 dark:bg-emerald-900/20'
-                            : 'border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600'
+                            ? "border-emerald-500 bg-emerald-50 dark:bg-emerald-900/20"
+                            : "border-slate-200 dark:border-slate-700 hover:border-slate-300 dark:hover:border-slate-600"
                         }`}
                       >
                         <div className="flex items-center justify-center space-x-2">
@@ -448,7 +448,7 @@ export default function PaymentSummary() {
                 </div>
 
                 {/* Token Amount Input */}
-                {paymentMethod !== 'STRIPE' && (
+                {paymentMethod !== "STRIPE" && (
                   <div>
                     <div className="flex items-center justify-between mb-4">
                       <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100">
@@ -463,7 +463,9 @@ export default function PaymentSummary() {
                         ) : (
                           <Eye className="w-4 h-4" />
                         )}
-                        <span>{showTokenDetails ? 'Hide' : 'Show'} Details</span>
+                        <span>
+                          {showTokenDetails ? "Hide" : "Show"} Details
+                        </span>
                       </button>
                     </div>
 
@@ -548,7 +550,8 @@ export default function PaymentSummary() {
                   <Button
                     onClick={handlePayment}
                     disabled={
-                      isProcessing || (paymentMethod !== 'STRIPE' && !tokenAmount)
+                      isProcessing ||
+                      (paymentMethod !== "STRIPE" && !tokenAmount)
                     }
                     className="flex-1 gradient-accent text-white floating-button relative overflow-hidden"
                   >
@@ -569,14 +572,14 @@ export default function PaymentSummary() {
                 {/* Additional Info */}
                 <div className="text-center">
                   <p className="text-xs text-slate-500 dark:text-slate-400">
-                    By proceeding, you agree to our{' '}
+                    By proceeding, you agree to our{" "}
                     <a
                       href="#"
                       className="text-emerald-600 dark:text-emerald-400 hover:underline"
                     >
                       Terms of Service
-                    </a>{' '}
-                    and{' '}
+                    </a>{" "}
+                    and{" "}
                     <a
                       href="#"
                       className="text-emerald-600 dark:text-emerald-400 hover:underline"

--- a/dashboard/hooks/usePayment.ts
+++ b/dashboard/hooks/usePayment.ts
@@ -1,0 +1,11 @@
+import { CreatePaymentIntentDto, usePaymentControllerCreateIntent } from "@/api";
+
+export function usePaymentMutation() {
+  const mutation = usePaymentControllerCreateIntent();
+
+  return {
+    ...mutation,
+    makePayment: (data: CreatePaymentIntentDto) =>
+      mutation.mutateAsync({ data }),
+  };
+}


### PR DESCRIPTION
## Summary
- fetch policy details on the payment page via `usePolicyQuery`
- enable Stripe-based payments alongside token payments
- hide token-specific fields when Stripe is selected
- add backend endpoint to create Stripe payment intents

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix dashboard run lint` *(fails: Parsing error: The keyword 'import' is reserved)*
- `npm --prefix backend install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@eslint%2feslintrc)*
- `npm --prefix backend run lint`

------
https://chatgpt.com/codex/tasks/task_e_688f064f57008320b810d5d8ff944095