### PR TITLE
Fix React.Children.only error by ensuring single child in ToastProvider

### DIFF
--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -26,9 +26,11 @@ export default function RootLayout({
         <Web3Providers>
           <ThemeProvider defaultTheme="light" storageKey="blocksecure-ui-theme">
             <ToastProvider>
-              <GlobalNavbar />
-              <main>{children}</main>
-              <Footer />
+              <>
+                <GlobalNavbar />
+                <main>{children}</main>
+                <Footer />
+              </>
             </ToastProvider>
           </ThemeProvider>
         </Web3Providers>

--- a/dashboard/components/shared/ToastProvider.tsx
+++ b/dashboard/components/shared/ToastProvider.tsx
@@ -36,31 +36,33 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <ToastContext.Provider value={{ printMessage }}>
-      {children}
-      <div className="fixed top-4 right-4 z-50 space-y-2">
-        {toasts.map((toast) => (
-          <div
-            key={toast.id}
-            className={cn(
-              "glass-card border px-4 py-3 rounded-md shadow-lg flex items-start justify-between animate-fade-in",
-              toast.type === "success" &&
-                "border-emerald-500 text-emerald-700 dark:text-emerald-400",
-              toast.type === "error" &&
-                "border-red-500 text-red-700 dark:text-red-400",
-              toast.type === "info" && "border-slate-200 dark:border-slate-700"
-            )}
-          >
-            <span className="pr-2">{toast.message}</span>
-            <button
-              onClick={() => removeToast(toast.id)}
-              aria-label="Close"
-              className="mt-0.5"
+      <>
+        {children}
+        <div className="fixed top-4 right-4 z-50 space-y-2">
+          {toasts.map((toast) => (
+            <div
+              key={toast.id}
+              className={cn(
+                "glass-card border px-4 py-3 rounded-md shadow-lg flex items-start justify-between animate-fade-in",
+                toast.type === "success" &&
+                  "border-emerald-500 text-emerald-700 dark:text-emerald-400",
+                toast.type === "error" &&
+                  "border-red-500 text-red-700 dark:text-red-400",
+                toast.type === "info" && "border-slate-200 dark:border-slate-700"
+              )}
             >
-              <X className="w-4 h-4" />
-            </button>
-          </div>
-        ))}
-      </div>
+              <span className="pr-2">{toast.message}</span>
+              <button
+                onClick={() => removeToast(toast.id)}
+                aria-label="Close"
+                className="mt-0.5"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+      </>
     </ToastContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- ensure ToastProvider passes a single element to its context provider
- wrap layout content in a fragment when using ToastProvider

## Testing
- `npm test --workspace dashboard` *(fails: Missing script "test")*
- `npm run lint --workspace dashboard` *(fails: Parsing error: The keyword 'import' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_6892edff494c832099880046560cbe66