### PR TITLE
Restrict policy repurchase and enhance dashboard UI

### DIFF
--- a/blockchain/contracts/InsuranceContract.sol
+++ b/blockchain/contracts/InsuranceContract.sol
@@ -133,6 +133,7 @@ contract InsuranceContract is Ownable, ReentrancyGuard {
         require(coverage > 0, "Coverage must be greater than 0");
         require(premium > 0, "Premium must be greater than 0");
         require(durationDays > 0, "Duration must be greater than 0");
+        require(userPolicies[msg.sender].length == 0, "Policy already purchased");
 
         uint256 policyId = nextPolicyId;
         uint256 startDate = block.timestamp;

--- a/dashboard/app/(policyholder)/policyholder/browse/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/browse/page.tsx
@@ -21,6 +21,7 @@ import PolicyDetailsDialog, {
 import Link from "next/link";
 import { logEvent } from "@/lib/analytics";
 import { usePoliciesQuery, useCategoryCountsQuery } from "@/hooks/usePolicies";
+import { useCoverageListQuery } from "@/hooks/useCoverage";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useToast } from "@/components/shared/ToastProvider";
 import {
@@ -76,6 +77,11 @@ export default function BrowsePolicies() {
   }, [sortBy]);
 
   const { data: categoryCountsData } = useCategoryCountsQuery();
+  const { data: coverageData } = useCoverageListQuery({ limit: 100 });
+
+  const purchasedPolicyIds = useMemo(() => {
+    return (coverageData?.data || []).map((c: any) => Number(c.policies?.id));
+  }, [coverageData]);
 
   const hasFilters = selectedCategory !== "all" || !!debouncedSearchTerm;
 
@@ -392,14 +398,20 @@ export default function BrowsePolicies() {
                       >
                         Details
                       </Button>
-                      <Link
-                        href={`/policyholder/payment?policy=${policy.id}`}
-                        className="flex-1"
-                      >
-                        <Button className="w-full gradient-accent text-white floating-button">
-                          Buy with Token
+                      {purchasedPolicyIds.includes(Number(policy.id)) ? (
+                        <Button className="flex-1" disabled>
+                          Purchased
                         </Button>
-                      </Link>
+                      ) : (
+                        <Link
+                          href={`/policyholder/payment?policy=${policy.id}`}
+                          className="flex-1"
+                        >
+                          <Button className="w-full gradient-accent text-white floating-button">
+                            Buy with Token
+                          </Button>
+                        </Link>
+                      )}
                     </div>
                   </CardContent>
                 </Card>

--- a/dashboard/app/(policyholder)/policyholder/coverage/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/coverage/page.tsx
@@ -291,14 +291,14 @@ export default function MyCoverage() {
                 <div className="w-12 h-12 rounded-xl bg-gradient-to-r from-blue-500 to-cyan-500 flex items-center justify-center">
                   <DollarSign className="w-6 h-6 text-white" />
                 </div>
-                <Badge className="status-badge status-info">Coverage</Badge>
+                <Badge className="status-badge status-info">Claimed</Badge>
               </div>
               <h3 className="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-1">
                 $
                 {(summaryData?.totalCoverageValue ?? 0).toLocaleString()}
               </h3>
               <p className="text-slate-600 dark:text-slate-400">
-                Total Coverage
+                Claimed
               </p>
             </CardContent>
           </Card>

--- a/dashboard/app/(policyholder)/policyholder/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/page.tsx
@@ -46,7 +46,7 @@ export default function PolicyholderDashboard() {
             icon={Shield}
           />
           <StatsCard
-            title="Total Coverage"
+            title="Claimed"
             value={formatValue(summary?.data?.totalCoverage, {
               currency: typeof summary?.data?.totalCoverage === "number",
             })}

--- a/dashboard/app/(policyholder)/policyholder/payment/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/payment/page.tsx
@@ -691,7 +691,7 @@ export default function PaymentSummary() {
                         value={tokenAmount || policyData.total}
                         onChange={(e) => setTokenAmount(e.target.value)}
                         placeholder={`Enter ${paymentMethod} amount`}
-                        className="form-input text-lg font-medium pr-20"
+                        className="form-input text-lg font-medium pr-20 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                         step="0.001"
                       />
                       <div className="absolute right-3 top-1/2 transform -translate-y-1/2 flex items-center space-x-2">

--- a/dashboard/components/shared/Navbar.tsx
+++ b/dashboard/components/shared/Navbar.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "./ThemeToggle";
 import { Connect } from "./Connect";
@@ -145,7 +146,10 @@ export function Navbar({ role }: NavbarProps) {
               <Link
                 key={index}
                 href={link.href}
-                className="nav-item whitespace-nowrap px-2 xl:px-3 2xl:px-4"
+                className={cn(
+                  "nav-item whitespace-nowrap px-2 xl:px-3 2xl:px-4",
+                  pathname === link.href && "nav-item-active"
+                )}
               >
                 {link.icon && <link.icon className="w-4 h-4 flex-shrink-0" />}
                 <span className="hidden xl:block">{link.label}</span>
@@ -286,7 +290,10 @@ export function Navbar({ role }: NavbarProps) {
                 <Link
                   key={index}
                   href={link.href}
-                  className="nav-item"
+                  className={cn(
+                    "nav-item",
+                    pathname === link.href && "nav-item-active"
+                  )}
                   onClick={() => setIsOpen(false)}
                 >
                   {link.icon && <link.icon className="w-4 h-4" />}


### PR DESCRIPTION
## Summary
- Prevent users from purchasing more than one policy via smart contract check
- Disable policy purchase button when already owned and highlight active navigation links
- Tweak coverage stats text to "Claimed" and remove number spinner from ETH amount field

## Testing
- `npm test` *(fails: HH502 Couldn't download compiler version list)*
- `npm run lint` *(fails: Parsing error: The keyword 'import' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_6898bd389df4832093dc4d41f618ce8e