### PR TITLE
feat: add Pinata integration for policy docs

### DIFF
--- a/backend/src/api/policy/policy.module.ts
+++ b/backend/src/api/policy/policy.module.ts
@@ -4,9 +4,10 @@ import { PolicyController } from './policy.controller';
 import { SupabaseModule } from 'src/supabase/supabase.module';
 import { ClaimModule } from '../claim/claim.module';
 import { FileModule } from '../file/file.module';
+import { PinataModule } from 'src/pinata/pinata.module';
 
 @Module({
-  imports: [SupabaseModule, ClaimModule, FileModule],
+  imports: [SupabaseModule, ClaimModule, FileModule, PinataModule],
   controllers: [PolicyController],
   providers: [PolicyService],
   exports: [PolicyService],

--- a/backend/src/pinata/pinata.module.ts
+++ b/backend/src/pinata/pinata.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { PinataService } from './pinata.service';
+
+@Module({
+  providers: [PinataService],
+  exports: [PinataService],
+})
+export class PinataModule {}
+

--- a/backend/src/pinata/pinata.service.ts
+++ b/backend/src/pinata/pinata.service.ts
@@ -1,0 +1,35 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { config } from 'dotenv';
+import { Blob } from 'buffer';
+
+config();
+
+@Injectable()
+export class PinataService {
+  private readonly endpoint = 'https://api.pinata.cloud/pinning/pinFileToIPFS';
+  private readonly jwt = process.env.PINATA_JWT!;
+
+  async uploadPolicyDocument(file: Express.Multer.File): Promise<string> {
+    const formData = new FormData();
+    formData.append('file', new Blob([file.buffer]), file.originalname);
+
+    const response = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.jwt}`,
+      },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const msg = await response.text();
+      throw new InternalServerErrorException(
+        `Failed to upload document to Pinata: ${msg}`,
+      );
+    }
+
+    const data = (await response.json()) as { IpfsHash: string };
+    return data.IpfsHash;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add PinataModule with service to upload files to Pinata via JWT
- wire PinataService into PolicyModule and PolicyService to store documents on IPFS
- skip deleting Pinata-hosted files when removing policies

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898c7f09f448320adba8903dfb00f8e