### PR TITLE
feat: handle coverage agreement uploads

### DIFF
--- a/backend/src/api/coverage/coverage.controller.ts
+++ b/backend/src/api/coverage/coverage.controller.ts
@@ -9,6 +9,8 @@ import {
   Req,
   UseGuards,
   Query,
+  UploadedFile,
+  UseInterceptors,
 } from '@nestjs/common';
 import { CoverageService } from './coverage.service';
 import { CreateCoverageDto } from './dto/requests/create-coverage.dto';
@@ -19,6 +21,7 @@ import { ApiBearerAuth } from '@nestjs/swagger';
 import { AuthenticatedRequest } from 'src/supabase/types/express';
 import { ApiCommonResponse, CommonResponseDto } from 'src/common/common.dto';
 import { CoverageResponseDto } from './dto/responses/coverage.dto';
+import { FileInterceptor } from '@nestjs/platform-express';
 
 @Controller('coverage')
 @ApiBearerAuth('supabase-auth')
@@ -32,6 +35,16 @@ export class CoverageController {
     @Req() req: AuthenticatedRequest,
   ) {
     return await this.coverageService.create(createCoverageDto, req);
+  }
+
+  @Post('agreement')
+  @UseGuards(AuthGuard)
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadAgreement(
+    @UploadedFile() file: Express.Multer.File,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.coverageService.uploadAgreement(file, req);
   }
 
   @Get()

--- a/backend/src/api/coverage/coverage.module.ts
+++ b/backend/src/api/coverage/coverage.module.ts
@@ -3,9 +3,10 @@ import { CoverageService } from './coverage.service';
 import { CoverageController } from './coverage.controller';
 import { SupabaseModule } from 'src/supabase/supabase.module';
 import { ClaimModule } from '../claim/claim.module';
+import { PinataModule } from 'src/pinata/pinata.module';
 
 @Module({
-  imports: [SupabaseModule, ClaimModule],
+  imports: [SupabaseModule, ClaimModule, PinataModule],
   controllers: [CoverageController],
   providers: [CoverageService],
 })

--- a/backend/src/api/coverage/coverage.service.ts
+++ b/backend/src/api/coverage/coverage.service.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
+import { PinataService } from 'src/pinata/pinata.service';
 import { CreateCoverageDto } from './dto/requests/create-coverage.dto';
 import { FindCoverageQueryDto } from './dto/responses/coverage-query.dto';
 import { CoverageResponseDto } from './dto/responses/coverage.dto';
@@ -14,6 +15,22 @@ import { CommonResponseDto } from 'src/common/common.dto';
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return */
 @Injectable()
 export class CoverageService {
+  constructor(private readonly pinataService: PinataService) {}
+
+  async uploadAgreement(
+    file: Express.Multer.File,
+    req: AuthenticatedRequest,
+  ) {
+    const cid = await this.pinataService.uploadPolicyDocument(file, {
+      userId: req.user.id,
+    });
+    return new CommonResponseDto({
+      statusCode: 201,
+      message: 'Agreement uploaded successfully',
+      data: { cid },
+    });
+  }
+
   async create(dto: CreateCoverageDto, req: AuthenticatedRequest) {
     //Insert into coverage table
     const { data: coverage, error: coverageError } = await req.supabase
@@ -26,6 +43,7 @@ export class CoverageService {
         start_date: dto.start_date,
         end_date: dto.end_date,
         next_payment_date: dto.next_payment_date,
+        agreement_cid: dto.agreement_cid,
       })
       .select()
       .single();

--- a/backend/src/api/coverage/dto/requests/create-coverage.dto.ts
+++ b/backend/src/api/coverage/dto/requests/create-coverage.dto.ts
@@ -5,6 +5,7 @@ import {
   IsDateString,
   IsNotEmpty,
   IsEnum,
+  IsString,
 } from 'class-validator';
 
 export enum CoverageStatus {
@@ -65,4 +66,12 @@ export class CreateCoverageDto {
   )
   @IsNotEmpty({ message: 'next_payment_date is required' })
   next_payment_date!: string;
+
+  @ApiProperty({
+    example: 'QmHash',
+    description: 'CID of the signed agreement stored on IPFS',
+  })
+  @IsString({ message: 'agreement_cid must be a string' })
+  @IsNotEmpty({ message: 'agreement_cid is required' })
+  agreement_cid!: string;
 }

--- a/backend/src/api/coverage/dto/responses/coverage.dto.ts
+++ b/backend/src/api/coverage/dto/responses/coverage.dto.ts
@@ -34,6 +34,9 @@ export class CoverageResponseDto {
   status!: string | null;
 
   @ApiProperty()
+  agreement_cid!: string;
+
+  @ApiProperty()
   utilization_rate!: number;
 
   @ApiProperty()

--- a/backend/src/api/policy/dto/responses/policy.dto.ts
+++ b/backend/src/api/policy/dto/responses/policy.dto.ts
@@ -13,6 +13,12 @@ export class PolicyDocumentResponseDto {
   @ApiProperty()
   policy_id!: number;
 
+  @ApiProperty()
+  path!: string;
+
+  @ApiProperty()
+  cid!: string;
+
   @ApiProperty({
     description: 'Signed Supabase URL for accessing this document',
   })

--- a/backend/src/api/policy/policy.service.ts
+++ b/backend/src/api/policy/policy.service.ts
@@ -221,6 +221,8 @@ export class PolicyService {
               id: doc.id,
               name: doc.name,
               policy_id: doc.policy_id,
+              path: doc.path,
+              cid: doc.cid,
               signedUrl: signedUrls[urlIndex++] || '',
             }))
           : [],

--- a/backend/swagger-spec.json
+++ b/backend/swagger-spec.json
@@ -2659,6 +2659,12 @@
           "policy_id": {
             "type": "number"
           },
+          "path": {
+            "type": "string"
+          },
+          "cid": {
+            "type": "string"
+          },
           "signedUrl": {
             "type": "string",
             "description": "Signed Supabase URL for accessing this document"
@@ -2668,6 +2674,8 @@
           "id",
           "name",
           "policy_id",
+          "path",
+          "cid",
           "signedUrl"
         ]
       },

--- a/dashboard/api/index.ts
+++ b/dashboard/api/index.ts
@@ -438,6 +438,8 @@ export interface PolicyDocumentResponseDto {
   id: number;
   name: string;
   policy_id: number;
+  path: string;
+  cid: string;
   /** Signed Supabase URL for accessing this document */
   signedUrl: string;
 }
@@ -519,6 +521,8 @@ export interface CreateCoverageDto {
   end_date: string;
   /** Next payment date for the coverage (YYYY-MM-DD) */
   next_payment_date: string;
+  /** CID of the signed agreement stored on IPFS */
+  agreement_cid: string;
 }
 
 export type CoveragePolicyDtoDescription = { [key: string]: unknown };
@@ -543,6 +547,7 @@ export interface CoverageResponseDto {
   policy_id?: CoverageResponseDtoPolicyId;
   user_id?: CoverageResponseDtoUserId;
   status?: CoverageResponseDtoStatus;
+  agreement_cid: string;
   utilization_rate: number;
   start_date: string;
   end_date: string;
@@ -563,6 +568,8 @@ export interface UpdateCoverageDto {
   end_date?: string;
   /** Next payment date for the coverage (YYYY-MM-DD) */
   next_payment_date?: string;
+  /** CID of the signed agreement stored on IPFS */
+  agreement_cid?: string;
 }
 
 export interface ExtractClaimDto {

--- a/dashboard/app/(policyholder)/policyholder/wallet/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/wallet/page.tsx
@@ -26,11 +26,9 @@ import {
   Filter,
   Calendar,
 } from "lucide-react";
-import {
-  walletBalance,
-  allTransactions,
-} from "@/public/data/policyholder/walletData";
+import { walletBalance } from "@/public/data/policyholder/walletData";
 import WalletSection from "@/components/shared/WalletSectiom";
+import { useWalletTransactions } from "@/hooks/useWalletTransactions";
 
 const ITEMS_PER_PAGE = 10;
 
@@ -39,8 +37,10 @@ export default function WalletPage() {
   const [filterType, setFilterType] = useState("all");
   const [filterStatus, setFilterStatus] = useState("all");
   const [dateRange, setDateRange] = useState("all");
+  const { transactions: chainTxs } = useWalletTransactions();
+  const transactions = useMemo(() => chainTxs, [chainTxs]);
   const filteredTransactions = useMemo(() => {
-    let filtered = allTransactions;
+    let filtered = transactions;
 
     // Filter by type
     if (filterType !== "all") {
@@ -81,7 +81,7 @@ export default function WalletPage() {
     return filtered.sort(
       (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
     );
-  }, [filterType, filterStatus, dateRange]);
+  }, [filterType, filterStatus, dateRange, transactions]);
 
   const totalPages = Math.ceil(filteredTransactions.length / ITEMS_PER_PAGE);
   const paginatedTransactions = filteredTransactions.slice(

--- a/dashboard/hooks/useAgreement.ts
+++ b/dashboard/hooks/useAgreement.ts
@@ -1,0 +1,20 @@
+import { CommonResponseDto } from '@/api';
+import { customFetcher } from '@/api/fetch';
+
+export function useAgreementUpload() {
+  const uploadAgreement = async (
+    agreementFile: File | null,
+  ): Promise<string | null> => {
+    if (!agreementFile) return null;
+    const formData = new FormData();
+    formData.append('file', agreementFile);
+    const res = await customFetcher<CommonResponseDto>({
+      url: '/coverage/agreement',
+      method: 'POST',
+      data: formData,
+    });
+    return (res.data as { cid: string }).cid as string;
+  };
+
+  return { uploadAgreement };
+}

--- a/dashboard/hooks/useWalletTransactions.ts
+++ b/dashboard/hooks/useWalletTransactions.ts
@@ -1,0 +1,57 @@
+import { useAccount, usePublicClient } from 'wagmi';
+import { formatEther } from 'viem';
+import { useEffect, useState } from 'react';
+
+export interface WalletTransaction {
+  id: string;
+  type: 'sent' | 'received';
+  amount: string;
+  description: string;
+  date: string;
+  status: 'confirmed';
+  hash: string;
+}
+
+export function useWalletTransactions(limit = 10) {
+  const { address } = useAccount();
+  const client = usePublicClient();
+  const [transactions, setTransactions] = useState<WalletTransaction[]>([]);
+
+  useEffect(() => {
+    const fetchTransactions = async () => {
+      if (!address) return;
+      const latestBlock = await client.getBlockNumber();
+      const txs: WalletTransaction[] = [];
+      let blockNumber = latestBlock;
+      while (txs.length < limit && blockNumber > 0n) {
+        const block = await client.getBlock({
+          blockNumber,
+          includeTransactions: true,
+        });
+        for (const tx of block.transactions) {
+          if (typeof tx === 'string') continue;
+          if (tx.from === address || tx.to === address) {
+            txs.push({
+              id: tx.hash,
+              type: tx.from === address ? 'sent' : 'received',
+              amount: `${formatEther(tx.value)} ETH`,
+              description: 'On-chain transaction',
+              date: new Date(Number(block.timestamp) * 1000)
+                .toISOString()
+                .split('T')[0],
+              status: 'confirmed',
+              hash: tx.hash,
+            });
+            if (txs.length >= limit) break;
+          }
+        }
+        blockNumber -= 1n;
+      }
+      setTransactions(txs);
+    };
+
+    fetchTransactions();
+  }, [address, client, limit]);
+
+  return { transactions };
+}


### PR DESCRIPTION
## Summary
- support uploading signed agreement to IPFS and saving CID in coverage records
- allow policyholders to download agreement template and upload signed PDF during payment
- display recently purchased policy transaction in wallet
- move agreement upload logic into reusable hook and read wallet transactions directly from chain
- fetch agreement template from policy documents instead of a bundled public file

## Testing
- `cd backend && npm test`
- `cd ../dashboard && npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error: The keyword 'import' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_6899c36c405c832087c56516b4e38462