### PR TITLE
Use Pinata URLs and fix agreement upload

### DIFF
--- a/backend/src/api/file/file.service.ts
+++ b/backend/src/api/file/file.service.ts
@@ -56,6 +56,12 @@ export class FileService {
   ): Promise<string[]> {
     const results = await Promise.all(
       filePaths.map(async (path) => {
+        // If the stored path is an IPFS URI, return the Pinata gateway URL
+        if (path.startsWith('ipfs://')) {
+          const cid = path.replace('ipfs://', '');
+          return `https://gateway.pinata.cloud/ipfs/${cid}`;
+        }
+
         const { data, error } = await supabase.storage
           .from(this.BUCKET)
           .createSignedUrl(path, this.SIGNED_URL_EXPIRY);

--- a/dashboard/api/index.ts
+++ b/dashboard/api/index.ts
@@ -4184,11 +4184,13 @@ export const coverageControllerUploadAgreement = (
   uploadDocDto: UploadDocDto,
   signal?: AbortSignal,
 ) => {
-  return customFetcher<null>({
+  const formData = new FormData();
+  uploadDocDto.files?.forEach((file) => formData.append("file", file));
+
+  return customFetcher<CommonResponseDto>({
     url: `/coverage/agreement`,
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    data: uploadDocDto,
+    data: formData,
     signal,
   });
 };

--- a/dashboard/app/(policyholder)/policyholder/payment/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/payment/page.tsx
@@ -31,7 +31,7 @@ import { usePolicyQuery } from '@/hooks/usePolicies';
 import { useToast } from '@/components/shared/ToastProvider';
 import { usePaymentMutation } from '@/hooks/usePayment';
 import { useInsuranceContract } from '@/hooks/useBlockchain';
-import { CreateCoverageDto, UploadDocDto } from '@/api';
+import { CreateCoverageDto } from '@/api';
 import { useTransactionStore } from '@/store/useTransactionStore';
 import { useAccount } from 'wagmi';
 import { useAgreementUploadMutation } from '@/hooks/useAgreement';
@@ -311,7 +311,7 @@ export default function PaymentSummary() {
 
     let cid = agreementCid;
     if (!cid) {
-      cid = await uploadAgreement(agreementFile as UploadDocDto);
+      cid = await uploadAgreement(agreementFile!);
       if (!cid) {
         printMessage('Failed to upload agreement.', 'error');
         return;

--- a/dashboard/hooks/useAgreement.ts
+++ b/dashboard/hooks/useAgreement.ts
@@ -6,8 +6,12 @@ export function useAgreementUploadMutation() {
 
   return {
     ...mutation,
-    uploadAgreement: (agreementFile: UploadDocDto) =>
-      mutation.mutateAsync({ data: agreementFile }),
+    uploadAgreement: async (agreementFile: File) => {
+      const res = await mutation.mutateAsync({
+        data: { files: [agreementFile] } as UploadDocDto,
+      });
+      return res.data as string;
+    },
     error: parseError(mutation.error),
   };
 }

--- a/dashboard/hooks/useWalletTransactions.ts
+++ b/dashboard/hooks/useWalletTransactions.ts
@@ -13,13 +13,13 @@ export interface WalletTransaction {
 }
 
 export function useWalletTransactions(limit = 10) {
-  const { address } = useAccount();
-  const client = usePublicClient();
+  const { address, chainId } = useAccount();
+  const client = usePublicClient({ chainId });
   const [transactions, setTransactions] = useState<WalletTransaction[]>([]);
 
   useEffect(() => {
     const fetchTransactions = async () => {
-      if (!address) return;
+      if (!address || !client) return;
       const latestBlock = await client.getBlockNumber();
       const txs: WalletTransaction[] = [];
       let blockNumber = latestBlock;


### PR DESCRIPTION
## Summary
- return Pinata gateway links for IPFS-backed documents
- send agreement uploads as multipart form data and return CID
- improve wallet transaction hook with chain-aware client

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `npm run lint` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899e58c82ac83209d3064d3dd90e36f