### PR TITLE
feat: add agreement cid to policy

### DIFF
--- a/blockchain/hardhat.config.ts
+++ b/blockchain/hardhat.config.ts
@@ -3,7 +3,7 @@ import '@nomicfoundation/hardhat-toolbox';
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: '0.8.28',
+    version: '0.8.20',
     settings: {
       optimizer: {
         enabled: true,


### PR DESCRIPTION
## Summary
- track agreement CID within on-chain Policy records
- require agreement CID when creating policies and before premium payments
- update tests and config for agreement CID functionality

## Testing
- `npx hardhat test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_689a0ef066048320af20c62113e71380