### PR TITLE
feat: add fluid tabs component to wallet page

### DIFF
--- a/dashboard/app/(policyholder)/policyholder/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/page.tsx
@@ -39,7 +39,7 @@ export default function PolicyholderDashboard() {
         </div>
 
         {/* Stats Overview */}
-        <div className="stats-grid">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
           <StatsCard
             title="Active Coverage"
             value={(summary?.data?.activeCoverage ?? 0).toString()}
@@ -56,13 +56,6 @@ export default function PolicyholderDashboard() {
             title="Pending Claims"
             value={(summary?.data?.pendingClaims ?? 0).toString()}
             icon={Clock}
-          />
-          <StatsCard
-            title="Wallet Balance"
-            value="5.2 ETH"
-            change="$18,420 USD"
-            changeType="neutral"
-            icon={Coins}
           />
         </div>
 
@@ -111,8 +104,8 @@ export default function PolicyholderDashboard() {
                               coverage.status === "Active"
                                 ? "status-active"
                                 : coverage.status === "Claimed"
-                                  ? "status-info"
-                                  : "status-pending"
+                                ? "status-info"
+                                : "status-pending"
                             }`}
                           >
                             {coverage.status}
@@ -185,8 +178,8 @@ export default function PolicyholderDashboard() {
                           activity.status === "completed"
                             ? "bg-emerald-100 dark:bg-emerald-900/30"
                             : activity.status === "pending"
-                              ? "bg-yellow-100 dark:bg-yellow-900/30"
-                              : "bg-blue-100 dark:bg-blue-900/30"
+                            ? "bg-yellow-100 dark:bg-yellow-900/30"
+                            : "bg-blue-100 dark:bg-blue-900/30"
                         }`}
                       >
                         {activity.status === "completed" ? (

--- a/dashboard/app/(policyholder)/policyholder/wallet/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/wallet/page.tsx
@@ -26,7 +26,7 @@ import {
   Calendar,
   ArrowLeftRight,
 } from "lucide-react";
-import FluidTabs from "@/components/ui/fluid-tabs";
+import FluidTabs from "@/components/animata/fluid-tabs";
 import { walletBalance } from "@/public/data/policyholder/walletData";
 import WalletSection from "@/components/shared/WalletSectiom";
 import { useWalletTransactions } from "@/hooks/useWalletTransactions";
@@ -172,47 +172,6 @@ export default function WalletPage() {
             </CardContent>
           </Card>
         </div>
-
-        {/* Token Holdings */}
-        <Card className="glass-card rounded-2xl mb-8">
-          <CardHeader>
-            <CardTitle className="text-xl text-slate-800 dark:text-slate-100">
-              Token Holdings
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
-              {walletBalance.tokens.map((token, index) => (
-                <div
-                  key={index}
-                  className="flex items-center justify-between p-4 bg-slate-50/50 dark:bg-slate-700/30 rounded-xl hover:bg-slate-100/50 dark:hover:bg-slate-700/50 transition-colors"
-                >
-                  <div className="flex items-center space-x-4">
-                    <div className="w-12 h-12 rounded-xl bg-gradient-to-r from-purple-500 to-indigo-500 flex items-center justify-center">
-                      <Coins className="w-6 h-6 text-white" />
-                    </div>
-                    <div>
-                      <h3 className="font-semibold text-slate-800 dark:text-slate-100">
-                        {token.symbol}
-                      </h3>
-                      <p className="text-sm text-slate-600 dark:text-slate-400">
-                        {token.name}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="text-right">
-                    <p className="font-semibold text-slate-800 dark:text-slate-100">
-                      {token.balance}
-                    </p>
-                    <p className="text-sm text-slate-600 dark:text-slate-400">
-                      ${token.usdValue}
-                    </p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
 
         {/* Transactions and Pending Payouts */}
         <FluidTabs

--- a/dashboard/app/(policyholder)/policyholder/wallet/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/wallet/page.tsx
@@ -4,7 +4,6 @@ import { useState, useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Select,
   SelectContent,
@@ -25,7 +24,9 @@ import {
   CheckCircle,
   Filter,
   Calendar,
+  ArrowLeftRight,
 } from "lucide-react";
+import FluidTabs from "@/components/ui/fluid-tabs";
 import { walletBalance } from "@/public/data/policyholder/walletData";
 import WalletSection from "@/components/shared/WalletSectiom";
 import { useWalletTransactions } from "@/hooks/useWalletTransactions";
@@ -214,224 +215,227 @@ export default function WalletPage() {
         </Card>
 
         {/* Transactions and Pending Payouts */}
-        <Tabs defaultValue="transactions" className="space-y-6">
-          <TabsList className="grid w-full grid-cols-2 bg-slate-100 dark:bg-slate-800 p-1 rounded-xl">
-            <TabsTrigger value="transactions" className="rounded-lg">
-              Transaction History
-            </TabsTrigger>
-            <TabsTrigger value="pending" className="rounded-lg">
-              Pending Payouts
-            </TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="transactions">
-            <Card className="glass-card rounded-2xl">
-              <CardHeader>
-                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-                  <div>
-                    <CardTitle className="text-xl text-slate-800 dark:text-slate-100">
-                      Recent Transactions
-                    </CardTitle>
-                    <p className="text-slate-600 dark:text-slate-400">
-                      Showing {paginatedTransactions.length} of{" "}
-                      {filteredTransactions.length} transactions
-                    </p>
-                  </div>
-
-                  {/* Filters */}
-                  <div className="flex flex-wrap gap-2">
-                    <Select
-                      value={filterType}
-                      onValueChange={(value) =>
-                        handleFilterChange(() => setFilterType(value))
-                      }
-                    >
-                      <SelectTrigger className="w-32 form-input">
-                        <Filter className="w-4 h-4 mr-2" />
-                        <SelectValue placeholder="Type" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="all">All Types</SelectItem>
-                        <SelectItem value="sent">Sent</SelectItem>
-                        <SelectItem value="received">Received</SelectItem>
-                      </SelectContent>
-                    </Select>
-
-                    <Select
-                      value={filterStatus}
-                      onValueChange={(value) =>
-                        handleFilterChange(() => setFilterStatus(value))
-                      }
-                    >
-                      <SelectTrigger className="w-32 form-input">
-                        <SelectValue placeholder="Status" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="all">All Status</SelectItem>
-                        <SelectItem value="completed">Completed</SelectItem>
-                        <SelectItem value="pending">Pending</SelectItem>
-                      </SelectContent>
-                    </Select>
-
-                    <Select
-                      value={dateRange}
-                      onValueChange={(value) =>
-                        handleFilterChange(() => setDateRange(value))
-                      }
-                    >
-                      <SelectTrigger className="w-32 form-input">
-                        <Calendar className="w-4 h-4 mr-2" />
-                        <SelectValue placeholder="Period" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="all">All Time</SelectItem>
-                        <SelectItem value="7days">Last 7 Days</SelectItem>
-                        <SelectItem value="30days">Last 30 Days</SelectItem>
-                        <SelectItem value="90days">Last 90 Days</SelectItem>
-                        <SelectItem value="1year">Last Year</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-4 mb-6">
-                  {paginatedTransactions.map((tx) => (
-                    <div
-                      key={tx.id}
-                      className="flex items-center justify-between p-4 bg-slate-50/50 dark:bg-slate-700/30 rounded-xl hover:bg-slate-100/50 dark:hover:bg-slate-700/50 transition-colors"
-                    >
-                      <div className="flex items-center space-x-4">
-                        <div
-                          className={`w-12 h-12 rounded-xl flex items-center justify-center ${
-                            tx.type === "received"
-                              ? "bg-gradient-to-r from-emerald-500 to-green-600"
-                              : "bg-gradient-to-r from-red-500 to-pink-500"
-                          }`}
-                        >
-                          {tx.type === "received" ? (
-                            <ArrowDownLeft className="w-6 h-6 text-white" />
-                          ) : (
-                            <ArrowUpRight className="w-6 h-6 text-white" />
-                          )}
-                        </div>
-                        <div>
-                          <h3 className="font-semibold text-slate-800 dark:text-slate-100">
-                            {tx.description}
-                          </h3>
-                          <div className="flex items-center space-x-2 text-sm text-slate-600 dark:text-slate-400">
-                            <span>
-                              {new Date(tx.date).toLocaleDateString()}
-                            </span>
-                            <span>•</span>
-                            <span>{formatAddress(tx.hash)}</span>
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              className="h-4 w-4 p-0"
-                            >
-                              <ExternalLink className="w-3 h-3" />
-                            </Button>
-                          </div>
-                        </div>
-                      </div>
-                      <div className="text-right">
-                        <p
-                          className={`font-semibold ${
-                            tx.type === "received"
-                              ? "text-emerald-600 dark:text-emerald-400"
-                              : "text-slate-800 dark:text-slate-100"
-                          }`}
-                        >
-                          {tx.type === "received" ? "+" : "-"}
-                          {tx.amount}
+        <FluidTabs
+          defaultTab="transactions"
+          tabs={[
+            {
+              id: "transactions",
+              label: "Transaction History",
+              icon: <ArrowLeftRight size={18} />,
+              content: (
+                <Card className="glass-card rounded-2xl">
+                  <CardHeader>
+                    <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+                      <div>
+                        <CardTitle className="text-xl text-slate-800 dark:text-slate-100">
+                          Recent Transactions
+                        </CardTitle>
+                        <p className="text-slate-600 dark:text-slate-400">
+                          Showing {paginatedTransactions.length} of{" "}
+                          {filteredTransactions.length} transactions
                         </p>
-                        <div className="flex items-center space-x-1">
-                          {tx.status === "confirmed" ? (
-                            <CheckCircle className="w-3 h-3 text-emerald-600 dark:text-emerald-400" />
-                          ) : (
-                            <Clock className="w-3 h-3 text-yellow-600 dark:text-yellow-400" />
-                          )}
-                          <span className="text-xs text-slate-500 dark:text-slate-500 capitalize">
-                            {tx.status}
-                          </span>
-                        </div>
+                      </div>
+
+                      {/* Filters */}
+                      <div className="flex flex-wrap gap-2">
+                        <Select
+                          value={filterType}
+                          onValueChange={(value) =>
+                            handleFilterChange(() => setFilterType(value))
+                          }
+                        >
+                          <SelectTrigger className="w-32 form-input">
+                            <Filter className="w-4 h-4 mr-2" />
+                            <SelectValue placeholder="Type" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="all">All Types</SelectItem>
+                            <SelectItem value="sent">Sent</SelectItem>
+                            <SelectItem value="received">Received</SelectItem>
+                          </SelectContent>
+                        </Select>
+
+                        <Select
+                          value={filterStatus}
+                          onValueChange={(value) =>
+                            handleFilterChange(() => setFilterStatus(value))
+                          }
+                        >
+                          <SelectTrigger className="w-32 form-input">
+                            <SelectValue placeholder="Status" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="all">All Status</SelectItem>
+                            <SelectItem value="completed">Completed</SelectItem>
+                            <SelectItem value="pending">Pending</SelectItem>
+                          </SelectContent>
+                        </Select>
+
+                        <Select
+                          value={dateRange}
+                          onValueChange={(value) =>
+                            handleFilterChange(() => setDateRange(value))
+                          }
+                        >
+                          <SelectTrigger className="w-32 form-input">
+                            <Calendar className="w-4 h-4 mr-2" />
+                            <SelectValue placeholder="Period" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="all">All Time</SelectItem>
+                            <SelectItem value="7days">Last 7 Days</SelectItem>
+                            <SelectItem value="30days">Last 30 Days</SelectItem>
+                            <SelectItem value="90days">Last 90 Days</SelectItem>
+                            <SelectItem value="1year">Last Year</SelectItem>
+                          </SelectContent>
+                        </Select>
                       </div>
                     </div>
-                  ))}
-                </div>
-
-                {/* Pagination */}
-                <Pagination
-                  currentPage={currentPage}
-                  totalPages={totalPages}
-                  onPageChange={setCurrentPage}
-                  showInfo={true}
-                  totalItems={filteredTransactions.length}
-                  itemsPerPage={ITEMS_PER_PAGE}
-                />
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          <TabsContent value="pending">
-            <Card className="glass-card rounded-2xl">
-              <CardHeader>
-                <CardTitle className="text-xl text-slate-800 dark:text-slate-100">
-                  Pending Payouts
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                {pendingPayouts.length > 0 ? (
-                  <div className="space-y-4">
-                    {pendingPayouts.map((payout) => (
-                      <div
-                        key={payout.id}
-                        className="flex items-center justify-between p-4 bg-yellow-50/50 dark:bg-yellow-900/20 rounded-xl border border-yellow-200/50 dark:border-yellow-700/50"
-                      >
-                        <div className="flex items-center space-x-4">
-                          <div className="w-12 h-12 rounded-xl bg-gradient-to-r from-yellow-500 to-orange-500 flex items-center justify-center">
-                            <Clock className="w-6 h-6 text-white" />
+                  </CardHeader>
+                  <CardContent>
+                    <div className="space-y-4 mb-6">
+                      {paginatedTransactions.map((tx) => (
+                        <div
+                          key={tx.id}
+                          className="flex items-center justify-between p-4 bg-slate-50/50 dark:bg-slate-700/30 rounded-xl hover:bg-slate-100/50 dark:hover:bg-slate-700/50 transition-colors"
+                        >
+                          <div className="flex items-center space-x-4">
+                            <div
+                              className={`w-12 h-12 rounded-xl flex items-center justify-center ${
+                                tx.type === "received"
+                                  ? "bg-gradient-to-r from-emerald-500 to-green-600"
+                                  : "bg-gradient-to-r from-red-500 to-pink-500"
+                              }`}
+                            >
+                              {tx.type === "received" ? (
+                                <ArrowDownLeft className="w-6 h-6 text-white" />
+                              ) : (
+                                <ArrowUpRight className="w-6 h-6 text-white" />
+                              )}
+                            </div>
+                            <div>
+                              <h3 className="font-semibold text-slate-800 dark:text-slate-100">
+                                {tx.description}
+                              </h3>
+                              <div className="flex items-center space-x-2 text-sm text-slate-600 dark:text-slate-400">
+                                <span>
+                                  {new Date(tx.date).toLocaleDateString()}
+                                </span>
+                                <span>•</span>
+                                <span>{formatAddress(tx.hash)}</span>
+                                <Button
+                                  size="sm"
+                                  variant="ghost"
+                                  className="h-4 w-4 p-0"
+                                >
+                                  <ExternalLink className="w-3 h-3" />
+                                </Button>
+                              </div>
+                            </div>
                           </div>
-                          <div>
-                            <h3 className="font-semibold text-slate-800 dark:text-slate-100">
-                              {payout.description}
-                            </h3>
-                            <p className="text-sm text-slate-600 dark:text-slate-400">
-                              Claim ID: {payout.claimId} • Est.{" "}
-                              {new Date(
-                                payout.estimatedDate
-                              ).toLocaleDateString()}
+                          <div className="text-right">
+                            <p
+                              className={`font-semibold ${
+                                tx.type === "received"
+                                  ? "text-emerald-600 dark:text-emerald-400"
+                                  : "text-slate-800 dark:text-slate-100"
+                              }`}
+                            >
+                              {tx.type === "received" ? "+" : "-"}
+                              {tx.amount}
                             </p>
+                            <div className="flex items-center space-x-1">
+                              {tx.status === "confirmed" ? (
+                                <CheckCircle className="w-3 h-3 text-emerald-600 dark:text-emerald-400" />
+                              ) : (
+                                <Clock className="w-3 h-3 text-yellow-600 dark:text-yellow-400" />
+                              )}
+                              <span className="text-xs text-slate-500 dark:text-slate-500 capitalize">
+                                {tx.status}
+                              </span>
+                            </div>
                           </div>
                         </div>
-                        <div className="text-right">
-                          <p className="font-semibold text-slate-800 dark:text-slate-100">
-                            +{payout.amount}
-                          </p>
-                          <Badge className="status-badge status-pending">
-                            <Clock className="w-3 h-3 mr-1" />
-                            Processing
-                          </Badge>
-                        </div>
+                      ))}
+                    </div>
+
+                    {/* Pagination */}
+                    <Pagination
+                      currentPage={currentPage}
+                      totalPages={totalPages}
+                      onPageChange={setCurrentPage}
+                      showInfo={true}
+                      totalItems={filteredTransactions.length}
+                      itemsPerPage={ITEMS_PER_PAGE}
+                    />
+                  </CardContent>
+                </Card>
+              ),
+            },
+            {
+              id: "pending",
+              label: "Pending Payouts",
+              icon: <Clock size={18} />,
+              content: (
+                <Card className="glass-card rounded-2xl">
+                  <CardHeader>
+                    <CardTitle className="text-xl text-slate-800 dark:text-slate-100">
+                      Pending Payouts
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    {pendingPayouts.length > 0 ? (
+                      <div className="space-y-4">
+                        {pendingPayouts.map((payout) => (
+                          <div
+                            key={payout.id}
+                            className="flex items-center justify-between p-4 bg-yellow-50/50 dark:bg-yellow-900/20 rounded-xl border border-yellow-200/50 dark:border-yellow-700/50"
+                          >
+                            <div className="flex items-center space-x-4">
+                              <div className="w-12 h-12 rounded-xl bg-gradient-to-r from-yellow-500 to-orange-500 flex items-center justify-center">
+                                <Clock className="w-6 h-6 text-white" />
+                              </div>
+                              <div>
+                                <h3 className="font-semibold text-slate-800 dark:text-slate-100">
+                                  {payout.description}
+                                </h3>
+                                <p className="text-sm text-slate-600 dark:text-slate-400">
+                                  Claim ID: {payout.claimId} • Est.{" "}
+                                  {new Date(
+                                    payout.estimatedDate
+                                  ).toLocaleDateString()}
+                                </p>
+                              </div>
+                            </div>
+                            <div className="text-right">
+                              <p className="font-semibold text-slate-800 dark:text-slate-100">
+                                +{payout.amount}
+                              </p>
+                              <Badge className="status-badge status-pending">
+                                <Clock className="w-3 h-3 mr-1" />
+                                Processing
+                              </Badge>
+                            </div>
+                          </div>
+                        ))}
                       </div>
-                    ))}
-                  </div>
-                ) : (
-                  <div className="text-center py-12">
-                    <Wallet className="w-16 h-16 text-slate-400 mx-auto mb-4" />
-                    <h3 className="text-xl font-semibold text-slate-600 dark:text-slate-400 mb-2">
-                      No pending payouts
-                    </h3>
-                    <p className="text-slate-500 dark:text-slate-500">
-                      All your claim payouts have been processed
-                    </p>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          </TabsContent>
-        </Tabs>
+                    ) : (
+                      <div className="text-center py-12">
+                        <Wallet className="w-16 h-16 text-slate-400 mx-auto mb-4" />
+                        <h3 className="text-xl font-semibold text-slate-600 dark:text-slate-400 mb-2">
+                          No pending payouts
+                        </h3>
+                        <p className="text-slate-500 dark:text-slate-500">
+                          All your claim payouts have been processed
+                        </p>
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              ),
+            },
+          ]}
+        />
       </div>
     </div>
   );

--- a/dashboard/components/animata/fluid-tabs.tsx
+++ b/dashboard/components/animata/fluid-tabs.tsx
@@ -47,11 +47,11 @@ export default function FluidTabs({ tabs, defaultTab }: FluidTabsProps) {
 
   return (
     <div className="space-y-6">
-      <div className="relative flex w-full space-x-2 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800 p-1 shadow-lg">
+      <div className="relative flex w-full space-x-2 overflow-hidden rounded-2xl bg-slate-100 dark:bg-slate-800 p-1 shadow-lg">
         <AnimatePresence initial={false}>
           <motion.div
             key={activeTab}
-            className="absolute inset-y-0 my-1 rounded-full bg-white dark:bg-slate-700"
+            className="absolute inset-y-0 my-1 rounded-2xl bg-white dark:bg-slate-700"
             initial={{ x: `${getTabIndex(prevActiveTab) * 100}%` }}
             animate={{ x: `${getTabIndex(activeTab) * 100}%` }}
             transition={{ type: "spring", stiffness: 300, damping: 30 }}
@@ -65,7 +65,7 @@ export default function FluidTabs({ tabs, defaultTab }: FluidTabsProps) {
               activeTab === tab.id
                 ? "text-slate-900 dark:text-slate-100"
                 : "text-slate-500"
-            } ${touchedTab === tab.id ? "blur-sm" : ""}`}
+            }`}
             onClick={() => handleTabClick(tab.id)}
           >
             {tab.icon}

--- a/dashboard/components/ui/fluid-tabs.tsx
+++ b/dashboard/components/ui/fluid-tabs.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useRef, useState, ReactNode } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+export interface FluidTab {
+  id: string;
+  label: string;
+  icon?: ReactNode;
+  content: ReactNode;
+}
+
+interface FluidTabsProps {
+  tabs: FluidTab[];
+  defaultTab?: string;
+}
+
+export default function FluidTabs({ tabs, defaultTab }: FluidTabsProps) {
+  const initialTab = defaultTab ?? tabs[0]?.id;
+  const [activeTab, setActiveTab] = useState(initialTab);
+  const [touchedTab, setTouchedTab] = useState<string | null>(null);
+  const [prevActiveTab, setPrevActiveTab] = useState(initialTab);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleTabClick = (tabId: string) => {
+    setPrevActiveTab(activeTab);
+    setActiveTab(tabId);
+    setTouchedTab(tabId);
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = setTimeout(() => {
+      setTouchedTab(null);
+    }, 300);
+  };
+
+  const getTabIndex = (tabId: string) => tabs.findIndex((tab) => tab.id === tabId);
+
+  return (
+    <div className="space-y-6">
+      <div className="relative flex w-full space-x-2 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800 p-1 shadow-lg">
+        <AnimatePresence initial={false}>
+          <motion.div
+            key={activeTab}
+            className="absolute inset-y-0 my-1 rounded-full bg-white dark:bg-slate-700"
+            initial={{ x: `${getTabIndex(prevActiveTab) * 100}%` }}
+            animate={{ x: `${getTabIndex(activeTab) * 100}%` }}
+            transition={{ type: "spring", stiffness: 300, damping: 30 }}
+            style={{ width: `${100 / tabs.length}%` }}
+          />
+        </AnimatePresence>
+        {tabs.map((tab) => (
+          <motion.button
+            key={tab.id}
+            className={`relative z-10 flex w-full items-center justify-center gap-1.5 px-5 py-3 text-sm font-bold transition-colors duration-300 ${
+              activeTab === tab.id
+                ? "text-slate-900 dark:text-slate-100"
+                : "text-slate-500"
+            } ${touchedTab === tab.id ? "blur-sm" : ""}`}
+            onClick={() => handleTabClick(tab.id)}
+          >
+            {tab.icon}
+            {tab.label}
+          </motion.button>
+        ))}
+      </div>
+      <div>
+        {tabs.map((tab) => (
+          <div key={tab.id} hidden={tab.id !== activeTab}>
+            {tab.content}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add animated FluidTabs component with theme-aware styling
- replace wallet page tabs with FluidTabs for transactions and payouts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error: The keyword 'import' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_689a2a360eec8320917cb110d4cc6e7e