### PR TITLE
Align transaction store with Supabase schema and update receipt dates

### DIFF
--- a/dashboard/app/(policyholder)/policyholder/payment/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/payment/page.tsx
@@ -264,17 +264,17 @@ export default function PaymentSummary() {
         });
       }
 
-      // Set transaction details
+      // Set transaction details in store
       setTransaction({
-        policyId: policyData!.id,
-        transactionId: createPolicyData!,
-        blockHash: createPolicyData!,
-        amount: policyData!.total,
-        usdAmount: Number((Number(policyData!.total) * 3500).toFixed(2)),
-        paymentMethod,
-        timestamp: new Date().toISOString(),
+        id: 0,
+        coverageId: coverage.data.id,
+        txHash: createPolicyData!,
+        description: `${policyData?.name} Purchased`,
+        amount: Number(tokenAmount),
+        currency: "ETH",
         status: "confirmed",
-        confirmations: 1,
+        type: "sent",
+        createdAt: new Date().toISOString(),
       });
 
       printMessage(
@@ -353,23 +353,23 @@ export default function PaymentSummary() {
         if (result.error || result.paymentIntent?.status !== "succeeded") {
           printMessage("Payment failed. Please try again.", "error");
         } else {
-          await createCoverage(coverageData);
+          const coverage = await createCoverage(coverageData);
 
           const txId = `PI-${Date.now()}`;
           const blockHash = `0x${Array.from({ length: 40 }, () =>
             Math.floor(Math.random() * 16).toString(16)
           ).join("")}`;
-          setTransaction({
-            policyId: policyData!.id,
-            transactionId: txId,
-            blockHash,
-            amount: policyData!.total,
-            usdAmount: Number((Number(policyData!.total) * 3500).toFixed(2)),
-            paymentMethod,
-            timestamp: new Date().toISOString(),
-            status: "confirmed",
-            confirmations: 1,
-          });
+            setTransaction({
+              id: 0,
+              coverageId: coverage?.data?.id ?? 0,
+              txHash: blockHash,
+              description: `${policyData?.name} Purchased`,
+              amount: policyData!.total,
+              currency: "USD",
+              status: "confirmed",
+              type: "sent",
+              createdAt: new Date().toISOString(),
+            });
 
           printMessage("Stripe payment successful", "success");
           router.push("/policyholder/payment/confirmation");

--- a/dashboard/store/useTransactionStore.ts
+++ b/dashboard/store/useTransactionStore.ts
@@ -1,15 +1,16 @@
 import { create } from "zustand";
 
+// Matches the Supabase transaction table structure
 export interface TransactionInfo {
-  policyId: number;
-  transactionId: string;
-  blockHash: string;
+  id: number; // Supabase transaction ID
+  coverageId: number; // Associated coverage
+  txHash: string; // Blockchain transaction hash
+  description: string;
   amount: number;
-  usdAmount: number;
-  paymentMethod: string;
-  timestamp: string;
+  currency: string;
   status: string;
-  confirmations: number;
+  type: string;
+  createdAt: string;
 }
 
 interface TransactionState {
@@ -19,15 +20,15 @@ interface TransactionState {
 }
 
 const initialData: TransactionInfo = {
-  policyId: 1,
-  transactionId: "",
-  blockHash: "",
+  id: 0,
+  coverageId: 0,
+  txHash: "",
+  description: "",
   amount: 0,
-  usdAmount: 0,
-  paymentMethod: "",
-  timestamp: "",
+  currency: "",
   status: "",
-  confirmations: 0,
+  type: "",
+  createdAt: "",
 };
 
 export const useTransactionStore = create<TransactionState>((set) => ({


### PR DESCRIPTION
## Summary
- align transaction Zustand store with Supabase transaction schema
- populate store with Supabase fields during blockchain and card payments
- set receipt statement/due dates from policy start and end dates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error: The keyword 'import' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_689b49b087b88320af0f8018467bb176