### PR TITLE
Integrate claim mutations for policyholder claims page

### DIFF
--- a/dashboard/app/(policyholder)/policyholder/claims/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/claims/page.tsx
@@ -28,6 +28,10 @@ import {
 } from "lucide-react";
 import { claims } from "@/public/data/policyholder/claimsData";
 import { useInsuranceContract } from "@/hooks/useBlockchain";
+import {
+  useCreateClaimMutation,
+  useUploadClaimDocumentsMutation,
+} from "@/hooks/useClaims";
 
 const ITEMS_PER_PAGE = 8;
 
@@ -42,8 +46,14 @@ export default function Claims() {
   const [selectedPolicy, setSelectedPolicy] = useState("");
   const [claimAmount, setClaimAmount] = useState("");
   const [description, setDescription] = useState("");
+  const [claimType, setClaimType] = useState("");
+
+  const priority = "low";
 
   const { fileClaimForPolicy, isFilingClaim } = useInsuranceContract();
+  const { createClaim, isPending: isCreating } = useCreateClaimMutation();
+  const { uploadClaimDocuments, isPending: isUploading } =
+    useUploadClaimDocumentsMutation();
   const sortedClaims = useMemo(() => {
     const sorted = [...claims].sort((a, b) => {
       switch (sortBy) {
@@ -423,7 +433,7 @@ export default function Claims() {
                   <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
                     Claim Type
                   </label>
-                  <Select>
+                  <Select value={claimType} onValueChange={setClaimType}>
                     <SelectTrigger className="form-input">
                       <SelectValue placeholder="Select claim type" />
                     </SelectTrigger>
@@ -538,15 +548,39 @@ export default function Claims() {
                 </Button>
                 <Button
                   className="flex-1 gradient-accent text-white floating-button"
-                  onClick={() => {
-                    if (!selectedPolicy || !claimAmount || !description) return;
-                    fileClaimForPolicy(
-                      Number(selectedPolicy),
-                      parseFloat(claimAmount),
-                      description
-                    );
+                  onClick={async () => {
+                    if (
+                      !selectedPolicy ||
+                      !claimType ||
+                      !claimAmount ||
+                      !description
+                    )
+                      return;
+                    const amount = parseFloat(claimAmount);
+                    try {
+                      const res = await createClaim({
+                        coverage_id: Number(selectedPolicy),
+                        type: claimType,
+                        priority,
+                        amount,
+                        description,
+                      });
+                      const claimId = (res as any)?.data?.id;
+                      if (claimId && selectedFiles.length > 0) {
+                        await uploadClaimDocuments(String(claimId), {
+                          files: selectedFiles,
+                        });
+                      }
+                      fileClaimForPolicy(
+                        Number(selectedPolicy),
+                        amount,
+                        description,
+                      );
+                    } catch (error) {
+                      console.error(error);
+                    }
                   }}
-                  disabled={isFilingClaim}
+                  disabled={isFilingClaim || isCreating || isUploading}
                 >
                   <Plus className="w-4 h-4 mr-2" />
                   Submit Claim


### PR DESCRIPTION
## Summary
- integrate create claim and upload documents mutations
- capture claim type in claim form
- submit selected documents alongside new claims

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Parsing error: The keyword 'import' is reserved)


------
https://chatgpt.com/codex/tasks/task_e_689ba875cea48320929c3ca6f967ef0b