### PR TITLE
feat: return coverage id after contract payment

### DIFF
--- a/backend/src/api/coverage/coverage.service.ts
+++ b/backend/src/api/coverage/coverage.service.ts
@@ -45,7 +45,7 @@ export class CoverageService {
           next_payment_date: dto.next_payment_date,
           agreement_cid: dto.agreement_cid,
         },
-        { onConflict: 'coverage_id' },
+        { onConflict: 'id' },
       )
       .select()
       .single();

--- a/dashboard/app/(policyholder)/policyholder/coverage/components/CoverageDetailsDialog.tsx
+++ b/dashboard/app/(policyholder)/policyholder/coverage/components/CoverageDetailsDialog.tsx
@@ -39,7 +39,7 @@ export default function CoverageDetailsDialog({
   open,
   onClose,
 }: CoverageDetailsDialogProps) {
-  const { payPremiumForPolicy, isPayingPremium, payPremiumData } =
+  const { payPremiumForCoverage, isPayingPremium, payPremiumData } =
     useInsuranceContract();
   const { createTransaction } = usePaymentMutation();
 
@@ -62,7 +62,7 @@ export default function CoverageDetailsDialog({
     if (!Number.isFinite(premiumAmount)) return;
 
     payingAmountRef.current = premiumAmount;
-    payPremiumForPolicy(0, premiumAmount);
+    payPremiumForCoverage(Number(policy.id), premiumAmount);
   };
 
   // After tx confirms -> record it ONCE, do not send a new tx
@@ -79,6 +79,7 @@ export default function CoverageDetailsDialog({
       if (!Number.isFinite(amount)) return;
 
       await createTransaction({
+        description: `Paid premium for policy ${policy.name}`,
         coverageId: Number(policy.id),
         txHash: payPremiumData,
         amount,

--- a/dashboard/app/(policyholder)/policyholder/payment/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/payment/page.tsx
@@ -411,7 +411,7 @@ export default function PaymentSummary() {
     const coverageId = await handleTokenPayment();
 
     const coverageData: CreateCoverageDto = {
-      id: coverageId,
+      id: coverageId!,
       policy_id: policyData!.id,
       status: "active",
       utilization_rate: 0,

--- a/dashboard/hooks/useBlockchain.ts
+++ b/dashboard/hooks/useBlockchain.ts
@@ -103,7 +103,7 @@ export function useInsuranceContract() {
         value: premiumWei,
       });
 
-      const receipt = await publicClient.waitForTransactionReceipt({ hash });
+      const receipt = await publicClient!.waitForTransactionReceipt({ hash });
 
       const event = receipt.logs
         .map((log) => {


### PR DESCRIPTION
## Summary
- decode `CoverageCreated` event to obtain coverage ID after `createCoverageWithPayment`
- return coverage ID to caller once transaction is mined

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error: The keyword 'import' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_689cb29be6f483209947010da7061291