### PR TITLE
Update next payment after premium

### DIFF
--- a/dashboard/app/(policyholder)/policyholder/coverage/components/CoverageDetailsDialog.tsx
+++ b/dashboard/app/(policyholder)/policyholder/coverage/components/CoverageDetailsDialog.tsx
@@ -85,6 +85,7 @@ export default function CoverageDetailsDialog({
         currency: "ETH",
         status: "confirmed",
         type: "sent",
+        description: "Premium Payment",
       });
     };
 


### PR DESCRIPTION
## Summary
- extend payment service to bump next_payment_date after premium transactions
- include transaction description for premium payments

## Testing
- `npm test` (backend)
- `npm test` (dashboard) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cbfe7eca483208a85f9929054f03f