### PR TITLE
feat: log policyholder activities

### DIFF
--- a/backend/src/api/user/user.module.ts
+++ b/backend/src/api/user/user.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { UserController } from './user.controller';
 import { SupabaseModule } from 'src/supabase/supabase.module';
 import { UserService } from './user.service';
+import { LoggerModule } from 'src/logger/logger.module';
 
 @Module({
-  imports: [SupabaseModule],
+  imports: [SupabaseModule, LoggerModule],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService],

--- a/backend/src/logger/activity-logger.service.ts
+++ b/backend/src/logger/activity-logger.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { SupabaseService } from 'src/supabase/supabase.service';
+
+@Injectable()
+export class ActivityLoggerService {
+  constructor(private readonly supabaseService: SupabaseService) {}
+
+  async log(action: string, userId: string, ip?: string): Promise<void> {
+    const supabase = this.supabaseService.createClientWithToken();
+    await supabase.from('activity_logs').insert({
+      action,
+      user_id: userId,
+      ip: ip ?? null,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}

--- a/backend/src/logger/logger.module.ts
+++ b/backend/src/logger/logger.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ActivityLoggerService } from './activity-logger.service';
+import { SupabaseModule } from 'src/supabase/supabase.module';
+
+@Module({
+  imports: [SupabaseModule],
+  providers: [ActivityLoggerService],
+  exports: [ActivityLoggerService],
+})
+export class LoggerModule {}


### PR DESCRIPTION
## Summary
- add ActivityLoggerService backed by Supabase
- log policyholder reads, creation, and updates

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe member access .JsonRpcProvider on an `error` typed value; Parsing error: test file not found)*
- `npx eslint src/api/user/user.module.ts src/api/user/user.service.ts src/logger/*.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cce6fc31c832087f3d1c7166da228