### PR TITLE
feat: add activity log endpoint and admin logging

### DIFF
--- a/backend/src/api/activity-log/activity-log.controller.ts
+++ b/backend/src/api/activity-log/activity-log.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ActivityLogService } from './activity-log.service';
+import { AuthGuard } from '../auth/auth.guard';
+import { ApiBearerAuth } from '@nestjs/swagger';
+import { ApiCommonResponse, CommonResponseDto } from 'src/common/common.dto';
+import { ActivityLogDto } from './dto/responses/activity-log.dto';
+import { FindActivityLogsQueryDto } from './dto/responses/activity-log-query.dto';
+
+@Controller('activity-logs')
+@ApiBearerAuth('supabase-auth')
+export class ActivityLogController {
+  constructor(private readonly activityLogService: ActivityLogService) {}
+
+  @Get()
+  @UseGuards(AuthGuard)
+  @ApiCommonResponse(ActivityLogDto, true, 'Get activity logs')
+  findAll(
+    @Query() query: FindActivityLogsQueryDto,
+  ): Promise<CommonResponseDto<ActivityLogDto[]>> {
+    return this.activityLogService.findAll(query);
+  }
+}

--- a/backend/src/api/activity-log/activity-log.module.ts
+++ b/backend/src/api/activity-log/activity-log.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ActivityLogService } from './activity-log.service';
+import { ActivityLogController } from './activity-log.controller';
+import { SupabaseModule } from 'src/supabase/supabase.module';
+
+@Module({
+  imports: [SupabaseModule],
+  controllers: [ActivityLogController],
+  providers: [ActivityLogService],
+})
+export class ActivityLogModule {}

--- a/backend/src/api/activity-log/activity-log.service.ts
+++ b/backend/src/api/activity-log/activity-log.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { SupabaseService } from 'src/supabase/supabase.service';
+import { FindActivityLogsQueryDto } from './dto/responses/activity-log-query.dto';
+import { ActivityLogDto } from './dto/responses/activity-log.dto';
+import { CommonResponseDto } from 'src/common/common.dto';
+
+@Injectable()
+export class ActivityLogService {
+  constructor(private readonly supabaseService: SupabaseService) {}
+
+  async findAll(
+    query: FindActivityLogsQueryDto,
+  ): Promise<CommonResponseDto<ActivityLogDto[]>> {
+    const supabase = this.supabaseService.createClientWithToken();
+    const offset = (query.page - 1) * query.limit;
+
+    let dbQuery = supabase
+      .from('activity_logs')
+      .select('*', { count: 'exact' })
+      .range(offset, offset + query.limit - 1)
+      .order('timestamp', { ascending: false });
+
+    if (query.userId) {
+      dbQuery = dbQuery.eq('user_id', query.userId);
+    }
+    if (query.action) {
+      dbQuery = dbQuery.eq('action', query.action);
+    }
+
+    const { data, error, count } = await dbQuery;
+
+    if (error) {
+      throw new InternalServerErrorException('Failed to fetch activity logs');
+    }
+
+    return new CommonResponseDto<ActivityLogDto[]>({
+      statusCode: 200,
+      message: 'Activity logs retrieved successfully',
+      data: (data || []).map((log) => new ActivityLogDto(log)),
+      count: count || 0,
+    });
+  }
+}

--- a/backend/src/api/activity-log/dto/responses/activity-log-query.dto.ts
+++ b/backend/src/api/activity-log/dto/responses/activity-log-query.dto.ts
@@ -1,0 +1,15 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+import { PaginatedQueryDto } from 'src/common/paginated-query.dto';
+
+export class FindActivityLogsQueryDto extends PaginatedQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by user ID' })
+  @IsOptional()
+  @IsString()
+  userId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by action' })
+  @IsOptional()
+  @IsString()
+  action?: string;
+}

--- a/backend/src/api/activity-log/dto/responses/activity-log.dto.ts
+++ b/backend/src/api/activity-log/dto/responses/activity-log.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ActivityLogDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  action!: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  user_id!: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  ip!: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  timestamp!: string | null;
+
+  constructor(partial: Partial<ActivityLogDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/backend/src/api/user/user.service.ts
+++ b/backend/src/api/user/user.service.ts
@@ -201,6 +201,9 @@ export class UserService {
     if (role === UserRole.POLICYHOLDER) {
       await this.activityLogger.log('POLICYHOLDER_READ', user_id);
     }
+    if (role === UserRole.INSURANCE_ADMIN) {
+      await this.activityLogger.log('INSURANCE_ADMIN_READ', user_id);
+    }
 
     return new CommonResponseDto<UserResponseDto>({
       statusCode: 200,
@@ -229,6 +232,9 @@ export class UserService {
 
     if (dto.role === UserRole.POLICYHOLDER) {
       await this.activityLogger.log('POLICYHOLDER_CREATED', user_id);
+    }
+    if (dto.role === UserRole.INSURANCE_ADMIN) {
+      await this.activityLogger.log('INSURANCE_ADMIN_CREATED', user_id);
     }
 
     return new CommonResponseDto<UserResponseDto>({
@@ -449,6 +455,7 @@ export class UserService {
       if (dto.company) {
         await this.updateOrInsertCompany(supabase, user_id, dto.company);
       }
+      await this.activityLogger.log('INSURANCE_ADMIN_UPDATED', user_id);
     }
 
     if (dto.role === UserRole.POLICYHOLDER) {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,6 +14,7 @@ import { ReviewsModule } from './api/reviews/reviews.module';
 import { CompanyModule } from './api/company/company.module';
 import { DashboardModule } from './api/dashboard/dashboard.module';
 import { PaymentModule } from './api/payment/payment.module';
+import { ActivityLogModule } from './api/activity-log/activity-log.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { PaymentModule } from './api/payment/payment.module';
     CompanyModule,
     DashboardModule,
     PaymentModule,
+    ActivityLogModule,
   ],
 
   controllers: [AppController],


### PR DESCRIPTION
## Summary
- expose activity logs via /activity-logs endpoint
- track insurance admin CRUD actions

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe member access in policy-scheduler)*
- `npx eslint src/api/activity-log/**/*.ts src/api/user/user.service.ts src/app.module.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cd3fcc2548320a34d6020c387f2ac