### PR TITLE
Fix agreement upload state for token payment

### DIFF
--- a/dashboard/app/(policyholder)/policyholder/payment/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/payment/page.tsx
@@ -295,8 +295,8 @@ export default function PaymentSummary() {
     }
   };
 
-  const handleTokenPayment = async () => {
-    if (!agreementCid) {
+  const handleTokenPayment = async (cid: string) => {
+    if (!cid) {
       printMessage("Please upload the signed agreement.", "error");
       return;
     }
@@ -319,7 +319,7 @@ export default function PaymentSummary() {
         policyData.coverageAmount, // coverage amount in ETH
         Number(tokenAmount), // premium amount in ETH
         parseInt(policyData.duration.split(" ")[0]), // duration in days
-        agreementCid,
+        cid,
         policyData.name,
         policyData.category,
         policyData.provider
@@ -408,7 +408,7 @@ export default function PaymentSummary() {
     nextPaymentDate.setMonth(nextPaymentDate.getMonth() + 1);
 
     // ETH payment
-    const coverageId = await handleTokenPayment();
+    const coverageId = await handleTokenPayment(cid);
 
     const coverageData: CreateCoverageDto = {
       id: coverageId!,


### PR DESCRIPTION
## Summary
- fix confirm payment failing on first click by using uploaded agreement CID directly in token payment handler

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Parsing error: The keyword 'import' is reserved)


------
https://chatgpt.com/codex/tasks/task_e_689d7fdd2284832097aeb6a62d0715aa