### PR TITLE
Add payment stats endpoint

### DIFF
--- a/backend/src/api/payment/dto/responses/payment-stats.dto.ts
+++ b/backend/src/api/payment/dto/responses/payment-stats.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsNumber, Min } from 'class-validator';
+
+export class PaymentStatsDto {
+  @ApiProperty({
+    type: Number,
+    example: 1000,
+    description: 'Total amount of payouts received by the user.',
+  })
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  totalPayoutsReceived!: number;
+
+  @ApiProperty({
+    type: Number,
+    example: 500,
+    description: 'Total premium amount the user needs to pay.',
+  })
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  totalPremiumToPay!: number;
+}

--- a/backend/src/api/payment/payment.controller.ts
+++ b/backend/src/api/payment/payment.controller.ts
@@ -16,6 +16,7 @@ import { AuthenticatedRequest } from 'src/supabase/types/express';
 import { AuthGuard } from '../auth/auth.guard';
 import { CreateTransactionDto } from './dto/requests/create-transaction.dto';
 import { TransactionResponseDto } from './dto/responses/transaction.dto';
+import { PaymentStatsDto } from './dto/responses/payment-stats.dto';
 
 @ApiTags('Payments')
 @Controller('payments')
@@ -49,6 +50,15 @@ export class PaymentController {
     @Req() req: AuthenticatedRequest,
   ): Promise<CommonResponseDto<TransactionResponseDto[]>> {
     return await this.paymentService.fetchTransactions(req);
+  }
+
+  @Get('stats')
+  @UseGuards(AuthGuard)
+  @ApiCommonResponse(PaymentStatsDto, false, 'Get payment stats')
+  async getStats(
+    @Req() req: AuthenticatedRequest,
+  ): Promise<CommonResponseDto<PaymentStatsDto>> {
+    return await this.paymentService.getPaymentStats(req);
   }
 
   @Get('transactions/:txHash')


### PR DESCRIPTION
## Summary
- add DTO and endpoint to fetch payment statistics
- compute total payouts received and premium amounts outstanding

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module '../../../blockchain/typechain-types/contracts/InsuranceContract')*

------
https://chatgpt.com/codex/tasks/task_e_689e368223f483209744557dfc599902