### PR TITLE
feat: integrate FluidTabs for claims page

### DIFF
--- a/dashboard/app/(policyholder)/policyholder/claims/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/claims/page.tsx
@@ -25,7 +25,6 @@ import {
   Eye,
   Download,
   X,
-  Shield,
 } from "lucide-react";
 import {
   Dialog,
@@ -33,6 +32,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import FluidTabs from "@/components/animata/fluid-tabs";
 import { useClaimsQuery } from "@/hooks/useClaims";
 import { useInsuranceContract } from "@/hooks/useBlockchain";
 import { usePolicyClaimTypesQuery } from "@/hooks/usePolicies";
@@ -379,29 +379,25 @@ export default function Claims() {
           </div>
         </div>
 
-        {/* Tab Navigation */}
-        <div className="flex space-x-1 mb-8 bg-slate-100 dark:bg-slate-800 p-1 rounded-xl w-fit">
-          <button
-            onClick={() => setActiveTab("my-claims")}
-            className={`px-6 py-2 rounded-lg font-medium transition-all ${
-              activeTab === "my-claims"
-                ? "bg-white dark:bg-slate-700 text-slate-800 dark:text-slate-100 shadow-sm"
-                : "text-slate-600 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200"
-            }`}
-          >
-            My Claims
-          </button>
-          <button
-            onClick={() => setActiveTab("new-claim")}
-            className={`px-6 py-2 rounded-lg font-medium transition-all ${
-              activeTab === "new-claim"
-                ? "bg-white dark:bg-slate-700 text-slate-800 dark:text-slate-100 shadow-sm"
-                : "text-slate-600 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200"
-            }`}
-          >
-            Submit New Claim
-          </button>
-        </div>
+        <FluidTabs
+          value={activeTab}
+          onValueChange={setActiveTab}
+          renderContent={false}
+          tabs={[
+            {
+              id: "my-claims",
+              label: "My Claims",
+              icon: <FileText size={18} />,
+              content: null,
+            },
+            {
+              id: "new-claim",
+              label: "Submit New Claim",
+              icon: <Plus size={18} />,
+              content: null,
+            },
+          ]}
+        />
 
         {activeTab === "my-claims" ? (
           /* My Claims Tab */

--- a/dashboard/components/animata/fluid-tabs.tsx
+++ b/dashboard/components/animata/fluid-tabs.tsx
@@ -13,11 +13,21 @@ export interface FluidTab {
 interface FluidTabsProps {
   tabs: FluidTab[];
   defaultTab?: string;
+  value?: string;
+  onValueChange?: (tabId: string) => void;
+  renderContent?: boolean;
 }
 
-export default function FluidTabs({ tabs, defaultTab }: FluidTabsProps) {
+export default function FluidTabs({
+  tabs,
+  defaultTab,
+  value,
+  onValueChange,
+  renderContent = true,
+}: FluidTabsProps) {
   const initialTab = defaultTab ?? tabs[0]?.id;
-  const [activeTab, setActiveTab] = useState(initialTab);
+  const [internalActiveTab, setInternalActiveTab] = useState(initialTab);
+  const activeTab = value ?? internalActiveTab;
   const [touchedTab, setTouchedTab] = useState<string | null>(null);
   const [prevActiveTab, setPrevActiveTab] = useState(initialTab);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -30,9 +40,19 @@ export default function FluidTabs({ tabs, defaultTab }: FluidTabsProps) {
     };
   }, []);
 
+  useEffect(() => {
+    if (value !== undefined && value !== activeTab) {
+      setPrevActiveTab(activeTab);
+    }
+  }, [value]);
+
   const handleTabClick = (tabId: string) => {
     setPrevActiveTab(activeTab);
-    setActiveTab(tabId);
+    if (onValueChange) {
+      onValueChange(tabId);
+    } else {
+      setInternalActiveTab(tabId);
+    }
     setTouchedTab(tabId);
 
     if (timeoutRef.current) {
@@ -73,13 +93,15 @@ export default function FluidTabs({ tabs, defaultTab }: FluidTabsProps) {
           </motion.button>
         ))}
       </div>
-      <div>
-        {tabs.map((tab) => (
-          <div key={tab.id} hidden={tab.id !== activeTab}>
-            {tab.content}
-          </div>
-        ))}
-      </div>
+      {renderContent && (
+        <div>
+          {tabs.map((tab) => (
+            <div key={tab.id} hidden={tab.id !== activeTab}>
+              {tab.content}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use shared FluidTabs component for claims tab navigation
- extend FluidTabs to allow external tab control and optional content rendering

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Parsing error: The keyword 'import' is reserved)


------
https://chatgpt.com/codex/tasks/task_e_689e3be5804483209bc25f385ed32b98