### PR TITLE
feat: replace navbar with theme-aware nav tabs

### DIFF
--- a/dashboard/components/animata/container/nav-tabs.tsx
+++ b/dashboard/components/animata/container/nav-tabs.tsx
@@ -31,7 +31,7 @@ export default function NavTabs({ tabs, className }: { tabs: NavTab[]; className
   return (
     <div
       className={cn(
-        "w-full flex flex-wrap items-center justify-center gap-4 rounded-md bg-slate-100 dark:bg-slate-900 p-6",
+        "w-full flex flex-wrap items-center justify-center gap-4 rounded-md bg-white/80 dark:bg-slate-800/90 p-6",
         className,
       )}
     >
@@ -61,7 +61,7 @@ const Tab = ({ tab, selected, setSelected }: TabProps) => {
         <motion.span
           layoutId="tabs"
           transition={{ type: "spring", duration: 0.5 }}
-          className="absolute inset-0 rounded-sm bg-slate-300 dark:bg-slate-700"
+          className="absolute inset-0 rounded-sm bg-gradient-to-r from-emerald-500 to-teal-500 dark:from-emerald-600 dark:to-teal-600"
         />
       )}
     </Link>

--- a/dashboard/components/animata/container/nav-tabs.tsx
+++ b/dashboard/components/animata/container/nav-tabs.tsx
@@ -61,7 +61,7 @@ const Tab = ({ tab, selected, setSelected }: TabProps) => {
         <motion.span
           layoutId="tabs"
           transition={{ type: "spring", duration: 0.5 }}
-          className="absolute inset-0 rounded-sm bg-gradient-to-r from-emerald-500 to-teal-500 dark:from-emerald-600 dark:to-teal-600"
+          className="absolute inset-0 rounded-sm bg-gradient-to-r from-emerald-500/80 to-teal-500/80 dark:from-emerald-600/80 dark:to-teal-600/80"
         />
       )}
     </Link>

--- a/dashboard/components/animata/container/nav-tabs.tsx
+++ b/dashboard/components/animata/container/nav-tabs.tsx
@@ -31,7 +31,7 @@ export default function NavTabs({ tabs, className }: { tabs: NavTab[]; className
   return (
     <div
       className={cn(
-        "flex flex-wrap items-center justify-center gap-4 rounded-md bg-violet-100 dark:bg-violet-950 p-6",
+        "w-full flex flex-wrap items-center justify-center gap-4 rounded-md bg-slate-100 dark:bg-slate-900 p-6",
         className,
       )}
     >
@@ -61,7 +61,7 @@ const Tab = ({ tab, selected, setSelected }: TabProps) => {
         <motion.span
           layoutId="tabs"
           transition={{ type: "spring", duration: 0.5 }}
-          className="absolute inset-0 rounded-sm bg-gradient-to-r from-indigo-600 to-pink-600"
+          className="absolute inset-0 rounded-sm bg-slate-300 dark:bg-slate-700"
         />
       )}
     </Link>

--- a/dashboard/components/animata/container/nav-tabs.tsx
+++ b/dashboard/components/animata/container/nav-tabs.tsx
@@ -49,14 +49,14 @@ const Tab = ({ tab, selected, setSelected }: TabProps) => {
       href={tab.href}
       onClick={() => setSelected(tab.href)}
       className={cn(
-        "relative rounded-md p-2 text-sm transition-all flex items-center gap-1",
+        "relative flex items-center justify-center gap-1 rounded-md p-2 text-sm transition-all min-w-20",
         selected
           ? "text-slate-900 dark:text-white"
           : "text-slate-600 dark:text-slate-300 hover:font-black",
       )}
     >
-      {Icon && <Icon className="w-4 h-4" />}
-      <p className="relative z-50 min-w-20">{tab.label}</p>
+      {Icon && <Icon className="relative z-50 h-4 w-4" />}
+      <p className="relative z-50 text-center">{tab.label}</p>
       {selected && (
         <motion.span
           layoutId="tabs"

--- a/dashboard/components/animata/container/nav-tabs.tsx
+++ b/dashboard/components/animata/container/nav-tabs.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import type { LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+interface NavTab {
+  href: string;
+  label: string;
+  icon?: LucideIcon;
+}
+
+interface TabProps {
+  tab: NavTab;
+  selected: boolean;
+  setSelected: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export default function NavTabs({ tabs, className }: { tabs: NavTab[]; className?: string }) {
+  const pathname = usePathname();
+  const [selected, setSelected] = useState<string>(pathname);
+
+  useEffect(() => {
+    setSelected(pathname);
+  }, [pathname]);
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center justify-center gap-4 rounded-md bg-violet-100 dark:bg-violet-950 p-6",
+        className,
+      )}
+    >
+      {tabs.map((tab) => (
+        <Tab tab={tab} selected={selected === tab.href} setSelected={setSelected} key={tab.href} />
+      ))}
+    </div>
+  );
+}
+
+const Tab = ({ tab, selected, setSelected }: TabProps) => {
+  const Icon = tab.icon;
+  return (
+    <Link
+      href={tab.href}
+      onClick={() => setSelected(tab.href)}
+      className={cn(
+        "relative rounded-md p-2 text-sm transition-all flex items-center gap-1",
+        selected
+          ? "text-slate-900 dark:text-white"
+          : "text-slate-600 dark:text-slate-300 hover:font-black",
+      )}
+    >
+      {Icon && <Icon className="w-4 h-4" />}
+      <p className="relative z-50 min-w-20">{tab.label}</p>
+      {selected && (
+        <motion.span
+          layoutId="tabs"
+          transition={{ type: "spring", duration: 0.5 }}
+          className="absolute inset-0 rounded-sm bg-gradient-to-r from-indigo-600 to-pink-600"
+        />
+      )}
+    </Link>
+  );
+};
+

--- a/dashboard/components/shared/Navbar.tsx
+++ b/dashboard/components/shared/Navbar.tsx
@@ -116,7 +116,7 @@ export function Navbar({ initialRole, initialUserId }: NavbarProps) {
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 glass-card border-b border-white/20 dark:border-slate-700/50 overflow-visible">
       <div className="w-full px-4 sm:px-6 lg:px-8 xl:px-12 2xl:px-16">
-        <div className="flex justify-between items-center h-16">
+        <div className="relative flex items-center h-16 justify-between">
           {/* Logo */}
           <Link
             href="/"
@@ -130,10 +130,13 @@ export function Navbar({ initialRole, initialUserId }: NavbarProps) {
             </span>
           </Link>
 
-          {/* Desktop Navigation - Responsive spacing */}
-            <div className="hidden lg:flex flex-1 justify-center max-w-4xl mx-8">
-              <NavTabs tabs={navigationLinks} className="bg-transparent p-0 rounded-none gap-2 xl:gap-4 2xl:gap-6" />
-            </div>
+          {/* Desktop Navigation - Centered */}
+          <div className="hidden lg:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+            <NavTabs
+              tabs={navigationLinks}
+              className="bg-transparent p-0 rounded-none gap-2 xl:gap-4 2xl:gap-6"
+            />
+          </div>
 
           {/* Right Side Actions */}
           <div className="hidden md:flex items-center space-x-2 lg:space-x-3 xl:space-x-4 flex-shrink-0">

--- a/dashboard/components/shared/Navbar.tsx
+++ b/dashboard/components/shared/Navbar.tsx
@@ -134,7 +134,7 @@ export function Navbar({ initialRole, initialUserId }: NavbarProps) {
           <div className="hidden lg:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
             <NavTabs
               tabs={navigationLinks}
-              className="bg-transparent p-0 rounded-none gap-2 xl:gap-4 2xl:gap-6"
+              className="p-0 rounded-none gap-2 xl:gap-4 2xl:gap-6"
             />
           </div>
 

--- a/dashboard/components/shared/Navbar.tsx
+++ b/dashboard/components/shared/Navbar.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import NavTabs from '@/components/animata/container/nav-tabs';
 import { usePathname, useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -130,24 +131,9 @@ export function Navbar({ initialRole, initialUserId }: NavbarProps) {
           </Link>
 
           {/* Desktop Navigation - Responsive spacing */}
-          <div className="hidden lg:flex items-center space-x-2 xl:space-x-4 2xl:space-x-6 flex-1 justify-center max-w-4xl mx-8">
-            {navigationLinks.map((link, index) => (
-              <Link
-                key={index}
-                href={link.href}
-                className={cn(
-                  'nav-item whitespace-nowrap px-2 xl:px-3 2xl:px-4',
-                  pathname === link.href && 'nav-item-active'
-                )}
-              >
-                {link.icon && <link.icon className="w-4 h-4 flex-shrink-0" />}
-                <span className="hidden xl:block">{link.label}</span>
-                <span className="xl:hidden text-xs">
-                  {link.label.split(' ')[0]}
-                </span>
-              </Link>
-            ))}
-          </div>
+            <div className="hidden lg:flex flex-1 justify-center max-w-4xl mx-8">
+              <NavTabs tabs={navigationLinks} className="bg-transparent p-0 rounded-none gap-2 xl:gap-4 2xl:gap-6" />
+            </div>
 
           {/* Right Side Actions */}
           <div className="hidden md:flex items-center space-x-2 lg:space-x-3 xl:space-x-4 flex-shrink-0">


### PR DESCRIPTION
## Summary
- use GlobalNavbar in layout for role-aware navigation
- render navigation items with dynamic NavTabs component
- support link objects and theme-aware styling in NavTabs

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Next.js plugin not detected; parsing errors)


------
https://chatgpt.com/codex/tasks/task_e_689e397be1fc8320843bbb1d57bcca89