### PR TITLE
feat: add payment stats hook

### DIFF
--- a/dashboard/app/(policyholder)/policyholder/wallet/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/wallet/page.tsx
@@ -29,7 +29,7 @@ import {
 import FluidTabs from "@/components/animata/fluid-tabs";
 import { walletBalance } from "@/public/data/policyholder/walletData";
 import WalletSection from "@/components/shared/WalletSectiom";
-import { useTransactionsQuery } from "@/hooks/usePayment";
+import { useTransactionsQuery, usePaymentStatsQuery } from "@/hooks/usePayment";
 import { TransactionResponseDto } from "@/api";
 
 const ITEMS_PER_PAGE = 10;
@@ -40,6 +40,7 @@ export default function WalletPage() {
   const [filterStatus, setFilterStatus] = useState("all");
   const [dateRange, setDateRange] = useState("all");
   const { data: savedTxs, error: chainTxsError } = useTransactionsQuery();
+  const { data: paymentStats } = usePaymentStatsQuery();
   const txArray = (savedTxs?.data ?? []) as TransactionResponseDto[];
 
   const transactions = useMemo(() => [...txArray], [txArray]);
@@ -150,7 +151,7 @@ export default function WalletPage() {
                 <Badge className="status-badge status-active">+12.5%</Badge>
               </div>
               <h3 className="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-1">
-                $162,950
+                {paymentStats?.data?.totalPayoutsReceived ?? 0} ETH
               </h3>
               <p className="text-slate-600 dark:text-slate-400">
                 Total Payouts Received
@@ -168,10 +169,10 @@ export default function WalletPage() {
                 <Badge className="status-badge status-info">Active</Badge>
               </div>
               <h3 className="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-1">
-                $3.5 ETH
+                {paymentStats?.data?.totalPremiumToPay ?? 0} ETH
               </h3>
               <p className="text-slate-600 dark:text-slate-400">
-                Monthly Premiums
+                Premiums Due
               </p>
             </CardContent>
           </Card>

--- a/dashboard/hooks/usePayment.ts
+++ b/dashboard/hooks/usePayment.ts
@@ -5,6 +5,7 @@ import {
   usePaymentControllerCreate,
   usePaymentControllerFindAll,
   usePaymentControllerFindOne,
+  usePaymentControllerGetStats,
 } from "@/api";
 import { parseError } from "@/utils/parseError";
 
@@ -24,6 +25,14 @@ export function usePaymentMutation() {
 export function useTransactionsQuery() {
   const query = usePaymentControllerFindAll();
 
+  return {
+    ...query,
+    error: parseError(query.error),
+  };
+}
+
+export function usePaymentStatsQuery() {
+  const query = usePaymentControllerGetStats();
   return {
     ...query,
     error: parseError(query.error),


### PR DESCRIPTION
## Summary
- fetch payment stats from API via new hook
- show user's payout and premium totals on wallet page
- remove unused payment stats section from payment page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Parsing error: The keyword 'import' is reserved)


------
https://chatgpt.com/codex/tasks/task_e_689e3b2e27048320b00862d6caac56db