### PR TITLE
Fix claim approval txHash handling

### DIFF
--- a/backend/src/api/claim/dto/requests/update-claim-status.dto.ts
+++ b/backend/src/api/claim/dto/requests/update-claim-status.dto.ts
@@ -1,11 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsString, IsOptional } from 'class-validator';
 
 export class UpdateClaimStatusDto {
   @ApiProperty({
     description: 'Transaction hash associated with the claim status update',
     example: '0x123abc456def789...',
   })
+  @IsOptional()
   @IsString()
   @IsNotEmpty()
   txHash?: string;

--- a/dashboard/app/(admin)/admin/claims/components/ClaimReviewDialog.tsx
+++ b/dashboard/app/(admin)/admin/claims/components/ClaimReviewDialog.tsx
@@ -93,6 +93,10 @@ export function ClaimReviewDialog({ claim, trigger }: ClaimReviewDialogProps) {
     try {
       if (reviewForm.status === "approved") {
         const claimHash = await approveClaimOnChain(Number(claim.id));
+        if (!claimHash) {
+          printMessage("Failed to approve claim", "error");
+          return;
+        }
 
         console.log("Claim approved on-chain:", claimHash);
 
@@ -100,16 +104,13 @@ export function ClaimReviewDialog({ claim, trigger }: ClaimReviewDialogProps) {
           String(claim.id),
           reviewForm.status as ClaimStatus,
           {
-            txHash: claimHash as string,
+            txHash: claimHash,
           }
         );
       } else {
         await updateClaimStatus(
           String(claim.id),
           reviewForm.status as ClaimStatus,
-          {
-            txHash: '', 
-          }
         );
       }
 

--- a/dashboard/hooks/useClaims.ts
+++ b/dashboard/hooks/useClaims.ts
@@ -76,7 +76,7 @@ export function useUpdateClaimStatusMutation() {
     updateClaimStatus: (
       id: string,
       status: ClaimStatus,
-      data: UpdateClaimStatusDto
+      data?: UpdateClaimStatusDto
     ) => mutation.mutateAsync({ id, status, data }),
     error: parseError(mutation.error),
   };


### PR DESCRIPTION
## Summary
- Allow claim status updates without transaction hash unless approving
- Ensure UI only patches claim after successful on-chain approval and includes tx hash

## Testing
- `npm test` (backend)
- `npm test` (dashboard) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e44f117b88320adfb0589fb1c0d64