### PR TITLE
Include reviews in policy list and update rating on review

### DIFF
--- a/backend/src/api/policy/policy.service.ts
+++ b/backend/src/api/policy/policy.service.ts
@@ -156,6 +156,7 @@ export class PolicyService {
       .select(
         `*,
      policy_documents(*),
+     reviews(*),
      policy_claim_type:policy_claim_type(
        claim_type:claim_types(name)
      ),
@@ -230,7 +231,8 @@ export class PolicyService {
 
     let urlIndex = 0;
     const enrichedPolicies: PolicyResponseDto[] = data.map((policy) => {
-      const { policy_claim_type, admin_details, ...rest } = policy as any;
+      const { policy_claim_type, admin_details, reviews, ...rest } =
+        policy as any;
 
       return {
         ...rest,
@@ -246,6 +248,7 @@ export class PolicyService {
               signedUrl: signedUrls[urlIndex++] || '',
             }))
           : [],
+        reviews: reviews || [],
         claim_types:
           policy_claim_type?.map((link) => link.claim_type.name) || [],
         sales: coverageMap.get(policy.id) || 0,

--- a/backend/src/api/reviews/reviews.service.ts
+++ b/backend/src/api/reviews/reviews.service.ts
@@ -58,6 +58,32 @@ export class ReviewsService {
       );
     }
 
+    // ✅ Step 4: Recalculate average rating for the policy
+    const { data: ratings, error: ratingsError } = await req.supabase
+      .from('reviews')
+      .select('rating')
+      .eq('policy_id', policyId);
+
+    if (ratingsError || !ratings) {
+      throw new InternalServerErrorException(
+        'Failed to recalculate policy rating',
+      );
+    }
+
+    const avgRating =
+      ratings.reduce((sum, r) => sum + r.rating, 0) / ratings.length;
+
+    const { error: updateError } = await req.supabase
+      .from('policies')
+      .update({ rating: avgRating })
+      .eq('id', policyId);
+
+    if (updateError) {
+      throw new InternalServerErrorException(
+        'Failed to update policy rating',
+      );
+    }
+
     return new CommonResponseDto({
       statusCode: 201,
       message: 'Review submitted successfully',


### PR DESCRIPTION
## Summary
- Return associated reviews when listing policies
- Recalculate policy rating whenever a review is submitted

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e4f05703c8320b51a973a3e1bdd27