### PR TITLE
feat(profile): circular crop for avatar

### DIFF
--- a/dashboard/app/(policyholder)/policyholder/profile/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/profile/page.tsx
@@ -157,10 +157,12 @@ export default function Profile() {
     canvas.height = size;
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
-    const sx = -position.x / zoom;
-    const sy = -position.y / zoom;
-    const sWidth = size / zoom;
-    const sHeight = size / zoom;
+    const img = imgRef.current;
+    const scale = img.naturalWidth / img.width;
+    const sx = (-position.x / zoom) * scale;
+    const sy = (-position.y / zoom) * scale;
+    const sWidth = (size / zoom) * scale;
+    const sHeight = (size / zoom) * scale;
     ctx.clearRect(0, 0, size, size);
     ctx.save();
     ctx.beginPath();
@@ -563,7 +565,7 @@ export default function Profile() {
                   style={{
                     width: "auto",
                     height: "auto",
-                    transform: `scale(${zoom}) translate(${position.x}px, ${position.y}px)`,
+                    transform: `translate(${position.x}px, ${position.y}px) scale(${zoom})`,
                     transformOrigin: "top left",
                     cursor: dragStart.current ? "grabbing" : "grab",
                   }}


### PR DESCRIPTION
## Summary
- crop profile images within a circular frame
- save avatar uploads as PNGs with transparent corners

## Testing
- `npm --prefix dashboard run lint` *(fails: The keyword 'import' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_689e510b2878832093cf2d73bc388898