### PR TITLE
Display policy reviews in details dialog

### DIFF
--- a/dashboard/app/(policyholder)/policyholder/browse/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/browse/page.tsx
@@ -131,6 +131,11 @@ export default function BrowsePolicies() {
       description:
         typeof policy.description === "string" ? policy.description : "",
       sales: policy.sales,
+      reviews: (policy.reviews || []).map((review: any) => ({
+        user: review.user_name,
+        rating: review.rating,
+        comment: typeof review.comment === "string" ? review.comment : "",
+      })),
     }));
   }, [policiesData]);
 


### PR DESCRIPTION
## Summary
- map policy reviews returned from API so they appear in the details dialog

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Parsing error: The keyword 'import' is reserved)


------
https://chatgpt.com/codex/tasks/task_e_689e53bf4e388320ac9a08540634466d