### PR TITLE
feat: animate coverage statistics with ticker

### DIFF
--- a/dashboard/app/(policyholder)/policyholder/coverage/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/coverage/page.tsx
@@ -13,6 +13,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Pagination } from "@/components/shared/Pagination";
+import Ticker from "@/components/animata/text/ticker";
 import {
   Shield,
   Calendar,
@@ -304,9 +305,10 @@ export default function MyCoverage() {
                 </div>
                 <Badge className="status-badge status-active">Active</Badge>
               </div>
-              <h3 className="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-1">
-                {summaryData?.activeCoverage ?? 0}
-              </h3>
+              <Ticker
+                value={String(summaryData?.activeCoverage ?? 0)}
+                className="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-1"
+              />
               <p className="text-slate-600 dark:text-slate-400">
                 Active Coverage
               </p>
@@ -321,9 +323,10 @@ export default function MyCoverage() {
                 </div>
                 <Badge className="status-badge status-info">Claimed</Badge>
               </div>
-              <h3 className="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-1">
-                ${(summaryData?.totalCoverageValue ?? 0).toLocaleString()}
-              </h3>
+              <Ticker
+                value={String(summaryData?.totalCoverageValue ?? 0)}
+                className="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-1"
+              />
               <p className="text-slate-600 dark:text-slate-400">Claimed</p>
             </CardContent>
           </Card>
@@ -336,9 +339,10 @@ export default function MyCoverage() {
                 </div>
                 <Badge className="status-badge status-warning">Claims</Badge>
               </div>
-              <h3 className="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-1">
-                {summaryData?.totalClaims ?? 0}
-              </h3>
+              <Ticker
+                value={String(summaryData?.totalClaims ?? 0)}
+                className="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-1"
+              />
               <p className="text-slate-600 dark:text-slate-400">Total Claims</p>
             </CardContent>
           </Card>
@@ -351,9 +355,13 @@ export default function MyCoverage() {
                 </div>
                 <Badge className="status-badge status-active">Rate</Badge>
               </div>
-              <h3 className="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-1">
-                {Math.round(summaryData?.approvalRate ?? 0)}%
-              </h3>
+              <div className="text-2xl font-bold text-slate-800 dark:text-slate-100 mb-1 flex items-baseline">
+                <Ticker
+                  value={String(Math.round(summaryData?.approvalRate ?? 0))}
+                  className="text-slate-800 dark:text-slate-100"
+                />
+                <span className="ml-1">%</span>
+              </div>
               <p className="text-slate-600 dark:text-slate-400">
                 Approval Rate
               </p>

--- a/dashboard/app/(policyholder)/policyholder/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/page.tsx
@@ -10,6 +10,7 @@ import { useAuthStore } from "@/store/useAuthStore";
 import { Shield, Clock, TrendingUp, Coins, FileText } from "lucide-react";
 import Link from "next/link";
 import { formatValue } from "@/utils/formatHelper";
+import Ticker from "@/components/animata/text/ticker";
 import { useMeQuery } from "@/hooks/useAuth";
 
 export default function PolicyholderDashboard() {
@@ -47,19 +48,32 @@ export default function PolicyholderDashboard() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
           <StatsCard
             title="Active Coverage"
-            value={(summary?.data?.activeCoverage ?? 0).toString()}
+            value={
+              <Ticker
+                value={String(summary?.data?.activeCoverage ?? 0)}
+                className="text-slate-800 dark:text-slate-100"
+              />
+            }
             icon={Shield}
           />
           <StatsCard
             title="Claimed"
-            value={formatValue(summary?.data?.totalCoverage, {
-              currency: typeof summary?.data?.totalCoverage === "number",
-            })}
+            value={
+              <Ticker
+                value={String(summary?.data?.totalCoverage ?? 0)}
+                className="text-slate-800 dark:text-slate-100"
+              />
+            }
             icon={TrendingUp}
           />
           <StatsCard
             title="Pending Claims"
-            value={(summary?.data?.pendingClaims ?? 0).toString()}
+            value={
+              <Ticker
+                value={String(summary?.data?.pendingClaims ?? 0)}
+                className="text-slate-800 dark:text-slate-100"
+              />
+            }
             icon={Clock}
           />
         </div>

--- a/dashboard/components/animata/text/ticker.tsx
+++ b/dashboard/components/animata/text/ticker.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { motion, useMotionValue, useSpring } from "framer-motion";
+
+import { cn } from "@/lib/utils";
+
+function Number({
+  value,
+  index,
+  total,
+  delay,
+  className,
+  getHeight,
+}: {
+  value: string;
+  index: number;
+  getHeight: () => number;
+  className?: string;
+  total: number;
+  delay?: number;
+}) {
+  const numberRef = useRef<HTMLDivElement>(null);
+  const motionValue = useMotionValue(0);
+  const springValue = useSpring(motionValue, {
+    stiffness: 150 - index * 2,
+    damping: 15,
+  });
+
+  const isRaw = String(+value) !== value;
+
+  useEffect(() => {
+    if (isRaw || !numberRef.current) {
+      return;
+    }
+
+    const update = () => {
+      const height = getHeight();
+      springValue.set(-height * +value);
+      // Add a delay to prevent the spring from firing too early.
+    };
+
+    if (!delay) {
+      update();
+      return;
+    }
+
+    const timer = setTimeout(update, (total - index) * Math.floor(Math.random() * delay));
+
+    return () => clearTimeout(timer);
+  }, [value, isRaw, springValue, getHeight, index, total, delay]);
+
+  if (isRaw) {
+    return <span>{value}</span>;
+  }
+
+  return (
+    <motion.div
+      ref={numberRef}
+      style={{
+        translateY: springValue,
+      }}
+    >
+      {Array.from({ length: 10 }).map((_, i) => (
+        <motion.div className={className} key={i}>
+          {i}
+        </motion.div>
+      ))}
+    </motion.div>
+  );
+}
+
+export default function Ticker({
+  value,
+  delay,
+  className,
+  numberClassName,
+}: {
+  value: string;
+  className?: string;
+  numberClassName?: string;
+  delay?: number;
+}) {
+  const parts = String(value).trim().split("");
+  const divRef = useRef<HTMLDivElement>(null);
+  const getHeight = useCallback(() => divRef.current?.getBoundingClientRect().height ?? 0, []);
+
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden whitespace-pre tabular-nums text-foreground",
+        className,
+      )}
+    >
+      <div className="absolute inset-0 flex min-w-fit">
+        {parts.map((part, index) => (
+          <Number
+            getHeight={getHeight}
+            index={index}
+            key={index}
+            value={part}
+            total={parts.length}
+            className={numberClassName}
+            delay={delay}
+          />
+        ))}
+      </div>
+      <div ref={divRef} className="invisible min-w-fit">
+        {value}
+      </div>
+    </div>
+  );
+}
+

--- a/dashboard/components/shared/StatsCard.tsx
+++ b/dashboard/components/shared/StatsCard.tsx
@@ -2,10 +2,11 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import type { LucideIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
 
 interface StatsCardProps {
   title: string;
-  value: string;
+  value: ReactNode;
   change?: string;
   changeType?: 'positive' | 'negative' | 'neutral';
   icon: LucideIcon;


### PR DESCRIPTION
## Summary
- allow StatsCard to render arbitrary value content
- animate policyholder dashboard stats using Ticker
- ensure coverage approval rate uses numeric ticker

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Parsing error: The keyword 'import' is reserved)


------
https://chatgpt.com/codex/tasks/task_e_689e5739aadc83208b01e0a1b09b4234