### PR TITLE
feat: support policy deactivation

### DIFF
--- a/backend/src/api/coverage/coverage.service.ts
+++ b/backend/src/api/coverage/coverage.service.ts
@@ -97,6 +97,7 @@ export class CoverageService {
         category,
         coverage,
         premium,
+        status,
         admin_details:admin_details!policies_created_by_fkey1(
           company:companies(name)
         )
@@ -171,6 +172,7 @@ export class CoverageService {
         category,
         coverage,
         premium,
+        status,
         duration_days,
         admin_details:admin_details!policies_created_by_fkey1(
           company:companies(name)

--- a/backend/src/api/coverage/dto/responses/coverage.dto.ts
+++ b/backend/src/api/coverage/dto/responses/coverage.dto.ts
@@ -24,6 +24,9 @@ export class CoveragePolicyDto {
 
   @ApiProperty()
   provider!: string;
+
+  @ApiProperty()
+  status!: string;
 }
 
 export class CoverageResponseDto {

--- a/dashboard/app/(policyholder)/policyholder/browse/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/browse/page.tsx
@@ -128,6 +128,7 @@ export default function BrowsePolicies() {
       features: policy.claim_types ?? [],
       popular: policy.popular,
       revenue: policy.revenue ?? 0,
+      status: policy.status,
       description:
         typeof policy.description === "string" ? policy.description : "",
       sales: policy.sales,
@@ -315,6 +316,11 @@ export default function BrowsePolicies() {
                   key={policy.id}
                   className="glass-card rounded-2xl card-hover relative overflow-hidden"
                 >
+                  {policy.status === "deactivated" && (
+                    <Badge className="absolute top-4 left-4 status-badge status-error">
+                      Deactivated
+                    </Badge>
+                  )}
                   {policy.popular && (
                     <Badge className="absolute top-4 right-4 bg-gradient-to-r from-emerald-500 to-teal-500 text-white">
                       Popular
@@ -409,7 +415,11 @@ export default function BrowsePolicies() {
                       >
                         Details
                       </Button>
-                      {purchasedPolicyIds.includes(Number(policy.id)) ? (
+                      {policy.status === "deactivated" ? (
+                        <Button className="flex-1" disabled>
+                          Deactivated
+                        </Button>
+                      ) : purchasedPolicyIds.includes(Number(policy.id)) ? (
                         <Button className="flex-1" disabled>
                           Purchased
                         </Button>

--- a/dashboard/app/(policyholder)/policyholder/coverage/components/CoverageDetailsDialog.tsx
+++ b/dashboard/app/(policyholder)/policyholder/coverage/components/CoverageDetailsDialog.tsx
@@ -33,12 +33,14 @@ interface CoverageDetailsDialogProps {
   coverage: CoveragePolicy;
   open: boolean;
   onClose: () => void;
+  policyDeactivated?: boolean;
 }
 
 export default function CoverageDetailsDialog({
   coverage,
   open,
   onClose,
+  policyDeactivated = false,
 }: CoverageDetailsDialogProps) {
   const {
     payPremiumForCoverage,
@@ -159,7 +161,7 @@ export default function CoverageDetailsDialog({
           <DialogFooter className="mt-4 gap-2">
             <Button
               onClick={handlePayPremium}
-              disabled={isPayingPremium || isWaitingPay}
+              disabled={policyDeactivated || isPayingPremium || isWaitingPay}
             >
               {isWaitingPay ? "Processing..." : "Pay Premium"}
             </Button>

--- a/dashboard/app/(policyholder)/policyholder/coverage/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/coverage/page.tsx
@@ -45,6 +45,7 @@ interface TransformedCoverage {
   coverage: string;
   premium: string;
   status: string;
+  policyStatus: string;
   startDate: string;
   endDate: string;
   nextPayment: string;
@@ -66,6 +67,7 @@ const transformCoverageData = (coverageData: any[]): TransformedCoverage[] => {
     const coverageAmount = policy?.coverage || 0;
     const utilizationAmount =
       (coverage.utilization_rate / 100) * coverageAmount;
+    const policyStatus = policy?.status || "active";
 
     return {
       id: coverage.id.toString(),
@@ -75,7 +77,8 @@ const transformCoverageData = (coverageData: any[]): TransformedCoverage[] => {
       provider: policy?.provider || "Unknown Provider",
       coverage: `$${coverageAmount.toLocaleString()}`,
       premium: policy?.premium || "0 ETH/month",
-      status: coverage.status || "active",
+      status: policyStatus === "deactivated" ? "deactivated" : coverage.status || "active",
+      policyStatus,
       startDate: coverage.start_date,
       endDate: coverage.end_date,
       nextPayment: coverage.next_payment_date,
@@ -192,6 +195,8 @@ export default function MyCoverage() {
         return "bg-slate-100 text-slate-800 dark:bg-slate-700/50 dark:text-slate-300";
       case "suspended":
         return "status-error";
+      case "deactivated":
+        return "status-error";
       default:
         return "bg-slate-100 text-slate-800 dark:bg-slate-700/50 dark:text-slate-300";
     }
@@ -241,6 +246,8 @@ export default function MyCoverage() {
         return "Expired";
       case "suspended":
         return "Suspended";
+      case "deactivated":
+        return "Deactivated";
       default:
         return status;
     }
@@ -402,6 +409,7 @@ export default function MyCoverage() {
                     </SelectItem>
                     <SelectItem value="expired">Expired</SelectItem>
                     <SelectItem value="suspended">Suspended</SelectItem>
+                    <SelectItem value="deactivated">Deactivated</SelectItem>
                   </SelectContent>
                 </Select>
 
@@ -605,6 +613,7 @@ export default function MyCoverage() {
                     variant="outline"
                     className="flex-1 floating-button"
                     onClick={() => openDetails(coverage)}
+                    disabled={coverage.policyStatus === "deactivated"}
                   >
                     <FileText className="w-4 h-4 mr-2" />
                     View Details
@@ -613,6 +622,7 @@ export default function MyCoverage() {
                     variant="outline"
                     className="flex-1 floating-button"
                     onClick={() => handleDownloadAgreement(coverage)}
+                    disabled={coverage.policyStatus === "deactivated"}
                   >
                     <Download className="w-4 h-4 mr-2" />
                     Download Agreement
@@ -628,6 +638,7 @@ export default function MyCoverage() {
             coverage={selectedCoverage}
             open={showDetails}
             onClose={closeDetails}
+            policyDeactivated={selectedCoverage.policyStatus === "deactivated"}
           />
         )}
 


### PR DESCRIPTION
## Summary
- repurpose policy deletion to mark a policy as deactivated
- show deactivated state in My Coverage and disable interactions
- block premium payments when a policy is deactivated

## Testing
- `npm test` (backend)
- `npm test` (dashboard) *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689eb73780c88320826a95a465887e7a