### PR TITLE
Add zod validation for admin and policyholder profiles

### DIFF
--- a/dashboard/app/(admin)/admin/profile/page.tsx
+++ b/dashboard/app/(admin)/admin/profile/page.tsx
@@ -62,13 +62,13 @@ const roleLabels: Record<string, string> = {
 };
 
 const profileSchema = z.object({
-  firstName: z.string().min(1, "First name is required"),
-  lastName: z.string().min(1, "Last name is required"),
-  phone: z.string().min(1, "Phone number is required"),
-  companyName: z.string().min(1, "Company name is required"),
-  companyAddress: z.string().min(1, "Company address is required"),
-  companyContactNo: z.string().min(1, "Company contact number is required"),
-  companyLicenseNo: z.string().min(1, "Company license number is required"),
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+  phone: z.string().optional(),
+  companyName: z.string().optional(),
+  companyAddress: z.string().optional(),
+  companyContactNo: z.string().optional(),
+  companyLicenseNo: z.string().optional(),
   bio: z.string().optional(),
 });
 

--- a/dashboard/app/(admin)/admin/profile/page.tsx
+++ b/dashboard/app/(admin)/admin/profile/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { z } from "zod";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -60,10 +61,23 @@ const roleLabels: Record<string, string> = {
   system_admin: "System Admin",
 };
 
+const profileSchema = z.object({
+  firstName: z.string().min(1, "First name is required"),
+  lastName: z.string().min(1, "Last name is required"),
+  phone: z.string().min(1, "Phone number is required"),
+  companyName: z.string().min(1, "Company name is required"),
+  companyAddress: z.string().min(1, "Company address is required"),
+  companyContactNo: z.string().min(1, "Company contact number is required"),
+  companyLicenseNo: z.string().min(1, "Company license number is required"),
+  bio: z.string().optional(),
+});
+
 export default function AdminProfile() {
   const [isEditing, setIsEditing] = useState(false);
   const [profileData, setProfileData] =
     useState<ProfileResponseDto>(defaultProfileData);
+  const [errors, setErrors] =
+    useState<Partial<Record<keyof z.infer<typeof profileSchema>, string>>>({});
   const [notifications, setNotifications] = useState(defaultNotifications);
   const { data: userResponse } = useMeQuery();
   const { data: activityLogs, isLoading: isActivityLoading } =
@@ -107,6 +121,23 @@ export default function AdminProfile() {
 
   const handleSave = async () => {
     if (!userResponse?.data?.id) return;
+    const result = profileSchema.safeParse(profileData);
+    if (!result.success) {
+      const fieldErrors = result.error.flatten().fieldErrors;
+      setErrors({
+        firstName: fieldErrors.firstName?.[0],
+        lastName: fieldErrors.lastName?.[0],
+        phone: fieldErrors.phone?.[0],
+        companyName: fieldErrors.companyName?.[0],
+        companyAddress: fieldErrors.companyAddress?.[0],
+        companyContactNo: fieldErrors.companyContactNo?.[0],
+        companyLicenseNo: fieldErrors.companyLicenseNo?.[0],
+        bio: fieldErrors.bio?.[0],
+      });
+      printMessage("Please correct the errors before saving", "error");
+      return;
+    }
+    setErrors({});
     try {
       await updateUser(userResponse.data.id, {
         firstName: profileData.firstName,
@@ -375,6 +406,11 @@ export default function AdminProfile() {
                           disabled={!isEditing}
                           className="form-input"
                         />
+                        {errors.firstName && (
+                          <p className="text-sm text-red-500 mt-1">
+                            {errors.firstName}
+                          </p>
+                        )}
                       </div>
                       <div>
                         <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
@@ -391,6 +427,11 @@ export default function AdminProfile() {
                           disabled={!isEditing}
                           className="form-input"
                         />
+                        {errors.lastName && (
+                          <p className="text-sm text-red-500 mt-1">
+                            {errors.lastName}
+                          </p>
+                        )}
                       </div>
                     </div>
 
@@ -426,6 +467,11 @@ export default function AdminProfile() {
                           disabled={!isEditing}
                           className="form-input"
                         />
+                        {errors.phone && (
+                          <p className="text-sm text-red-500 mt-1">
+                            {errors.phone}
+                          </p>
+                        )}
                       </div>
                     </div>
                     <CardTitle className="text-xl text-slate-800 dark:text-slate-100">
@@ -447,6 +493,11 @@ export default function AdminProfile() {
                           disabled={!isEditing}
                           className="form-input"
                         />
+                        {errors.companyName && (
+                          <p className="text-sm text-red-500 mt-1">
+                            {errors.companyName}
+                          </p>
+                        )}
                       </div>
                       <div>
                         <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
@@ -463,6 +514,11 @@ export default function AdminProfile() {
                           disabled={!isEditing}
                           className="form-input"
                         />
+                        {errors.companyAddress && (
+                          <p className="text-sm text-red-500 mt-1">
+                            {errors.companyAddress}
+                          </p>
+                        )}
                       </div>
                     </div>
 
@@ -482,6 +538,11 @@ export default function AdminProfile() {
                           disabled={!isEditing}
                           className="form-input"
                         />
+                        {errors.companyContactNo && (
+                          <p className="text-sm text-red-500 mt-1">
+                            {errors.companyContactNo}
+                          </p>
+                        )}
                       </div>
                       <div>
                         <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
@@ -498,6 +559,11 @@ export default function AdminProfile() {
                           disabled={!isEditing}
                           className="form-input"
                         />
+                        {errors.companyLicenseNo && (
+                          <p className="text-sm text-red-500 mt-1">
+                            {errors.companyLicenseNo}
+                          </p>
+                        )}
                       </div>
                     </div>
 
@@ -516,6 +582,11 @@ export default function AdminProfile() {
                         disabled={!isEditing}
                         className="form-input min-h-[100px]"
                       />
+                      {errors.bio && (
+                        <p className="text-sm text-red-500 mt-1">
+                          {errors.bio}
+                        </p>
+                      )}
                     </div>
                   </CardContent>
                 </Card>

--- a/dashboard/app/(policyholder)/policyholder/profile/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/profile/page.tsx
@@ -42,12 +42,12 @@ import {
 } from "@/components/ui/dialog";
 
 const profileSchema = z.object({
-  firstName: z.string().min(1, "First name is required"),
-  lastName: z.string().min(1, "Last name is required"),
-  phone: z.string().min(1, "Phone number is required"),
-  address: z.string().min(1, "Address is required"),
-  dateOfBirth: z.string().min(1, "Date of birth is required"),
-  occupation: z.string().min(1, "Occupation is required"),
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+  phone: z.string().optional(),
+  address: z.string().optional(),
+  dateOfBirth: z.string().optional(),
+  occupation: z.string().optional(),
   bio: z.string().optional(),
 });
 

--- a/dashboard/app/(policyholder)/policyholder/profile/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/profile/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { z } from "zod";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -40,11 +41,23 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 
+const profileSchema = z.object({
+  firstName: z.string().min(1, "First name is required"),
+  lastName: z.string().min(1, "Last name is required"),
+  phone: z.string().min(1, "Phone number is required"),
+  address: z.string().min(1, "Address is required"),
+  dateOfBirth: z.string().min(1, "Date of birth is required"),
+  occupation: z.string().min(1, "Occupation is required"),
+  bio: z.string().optional(),
+});
+
 export default function Profile() {
   const [isEditing, setIsEditing] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [profileData, setProfileData] =
     useState<ProfileResponseDto>(initialProfileData);
+  const [errors, setErrors] =
+    useState<Partial<Record<keyof z.infer<typeof profileSchema>, string>>>({});
   const [notifications, setNotifications] = useState(initialNotifications);
   const { data: userResponse } = useMeQuery();
   const { data: activityLogs, isLoading: isActivityLoading } =
@@ -87,6 +100,22 @@ export default function Profile() {
   }, [userResponse]);
   const handleSave = async () => {
     if (!userResponse?.data?.id) return;
+    const result = profileSchema.safeParse(profileData);
+    if (!result.success) {
+      const fieldErrors = result.error.flatten().fieldErrors;
+      setErrors({
+        firstName: fieldErrors.firstName?.[0],
+        lastName: fieldErrors.lastName?.[0],
+        phone: fieldErrors.phone?.[0],
+        address: fieldErrors.address?.[0],
+        dateOfBirth: fieldErrors.dateOfBirth?.[0],
+        occupation: fieldErrors.occupation?.[0],
+        bio: fieldErrors.bio?.[0],
+      });
+      printMessage("Please correct the errors before saving", "error");
+      return;
+    }
+    setErrors({});
     try {
       await updateUser(userResponse.data.id, {
         role: profileData.role,
@@ -366,6 +395,11 @@ export default function Profile() {
                             disabled={!isEditing}
                             className="form-input"
                           />
+                          {errors.firstName && (
+                            <p className="text-sm text-red-500 mt-1">
+                              {errors.firstName}
+                            </p>
+                          )}
                         </div>
                         <div>
                           <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
@@ -376,12 +410,17 @@ export default function Profile() {
                             onChange={(e) =>
                               setProfileData({
                                 ...profileData,
-                                lastName: e.target.value,
-                              })
-                            }
-                            disabled={!isEditing}
-                            className="form-input"
-                          />
+                              lastName: e.target.value,
+                            })
+                          }
+                          disabled={!isEditing}
+                          className="form-input"
+                        />
+                          {errors.lastName && (
+                            <p className="text-sm text-red-500 mt-1">
+                              {errors.lastName}
+                            </p>
+                          )}
                         </div>
                       </div>
 
@@ -417,6 +456,11 @@ export default function Profile() {
                             disabled={!isEditing}
                             className="form-input"
                           />
+                          {errors.phone && (
+                            <p className="text-sm text-red-500 mt-1">
+                              {errors.phone}
+                            </p>
+                          )}
                         </div>
                       </div>
 
@@ -435,6 +479,11 @@ export default function Profile() {
                           disabled={!isEditing}
                           className="form-input"
                         />
+                        {errors.address && (
+                          <p className="text-sm text-red-500 mt-1">
+                            {errors.address}
+                          </p>
+                        )}
                       </div>
 
                       <div className="grid md:grid-cols-2 gap-6">
@@ -454,6 +503,11 @@ export default function Profile() {
                             disabled={!isEditing}
                             className="form-input"
                           />
+                          {errors.dateOfBirth && (
+                            <p className="text-sm text-red-500 mt-1">
+                              {errors.dateOfBirth}
+                            </p>
+                          )}
                         </div>
                         <div>
                           <label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
@@ -470,6 +524,11 @@ export default function Profile() {
                             disabled={!isEditing}
                             className="form-input"
                           />
+                          {errors.occupation && (
+                            <p className="text-sm text-red-500 mt-1">
+                              {errors.occupation}
+                            </p>
+                          )}
                         </div>
                       </div>
 
@@ -488,6 +547,11 @@ export default function Profile() {
                           disabled={!isEditing}
                           className="form-input min-h-[100px]"
                         />
+                        {errors.bio && (
+                          <p className="text-sm text-red-500 mt-1">
+                            {errors.bio}
+                          </p>
+                        )}
                       </div>
                     </CardContent>
                   </Card>


### PR DESCRIPTION
## Summary
- validate insurance admin profile fields with Zod before saving
- add policyholder profile schema and inline error handling

## Testing
- `npm run lint` *(fails: Parsing error: The keyword 'import' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_689ebc199e8c83208f8573300db92cf4