### PR TITLE
Add WaveReveal animation for policyholder greeting

### DIFF
--- a/dashboard/app/(policyholder)/policyholder/page.tsx
+++ b/dashboard/app/(policyholder)/policyholder/page.tsx
@@ -11,6 +11,7 @@ import { Shield, Clock, TrendingUp, Coins, FileText } from "lucide-react";
 import Link from "next/link";
 import { formatValue } from "@/utils/formatHelper";
 import Ticker from "@/components/animata/text/ticker";
+import WaveReveal from "@/components/animata/text/wave-reveal";
 import { useMeQuery } from "@/hooks/useAuth";
 
 export default function PolicyholderDashboard() {
@@ -33,10 +34,13 @@ export default function PolicyholderDashboard() {
               <Shield className="w-6 h-6 text-white" />
             </div>
             <div>
-              <h1 className="page-header-title">
-                Welcome back, {userResponse?.data?.firstName}{" "}
-                {userResponse?.data?.lastName}!
-              </h1>
+              <WaveReveal
+                text={`Welcome back, ${userResponse?.data?.firstName ?? ""} ${userResponse?.data?.lastName ?? ""}!`}
+                className="page-header-title"
+                letterClassName="text-slate-800 dark:text-slate-100"
+                direction="down"
+                mode="letter"
+              />
               <p className="page-header-subtitle">
                 Manage your policies and track your coverage
               </p>

--- a/dashboard/components/animata/text/wave-reveal.tsx
+++ b/dashboard/components/animata/text/wave-reveal.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface WaveRevealProps {
+  /**
+   * The text to animate
+   */
+  text: string;
+
+  /**
+   * Additional classes for the container
+   */
+  className?: string;
+
+  /**
+   * The direction of the animation
+   * @default "down"
+   */
+  direction?: "up" | "down";
+
+  /**
+   * The mode of the animation
+   * @default "letter"
+   */
+  mode?: "letter" | "word";
+
+  /**
+   * Duration of the animation
+   * E.g. 2000ms
+   */
+  duration?: string;
+
+  /**
+   * If true, the text will apply a blur effect as seen in WWDC.
+   */
+  blur?: boolean;
+
+  letterClassName?: string;
+
+  /**
+   * Delay for each letter/word in ms
+   */
+  delay?: number;
+}
+
+interface ReducedValue extends Pick<WaveRevealProps, "direction" | "mode"> {
+  nodes: ReactNode[];
+  offset: number;
+  duration: number | string;
+  delay: number;
+  blur?: boolean;
+  className?: string;
+  wordsLength: number;
+  textLength: number;
+}
+
+const Word = ({
+  isWordMode,
+  word,
+  index,
+  offset,
+  delay,
+  duration,
+  className,
+}: Pick<ReducedValue, "delay" | "duration" | "offset"> & {
+  index: number;
+  className: string;
+  isWordMode: boolean;
+  word: string;
+  length: number;
+}) => {
+  if (isWordMode) {
+    return word;
+  }
+
+  return (
+    <>
+      {word.split("").map((letter, letterIndex) => {
+        return (
+          <span
+            key={`${letter}_${letterIndex}_${index}`}
+            className={cn({
+              [className]: !isWordMode,
+            })}
+            style={{
+              animationDuration: `${duration}`,
+              animationDelay: createDelay({
+                index: letterIndex,
+                offset,
+                delay,
+              }),
+            }}
+          >
+            {letter}
+          </span>
+        );
+      })}
+    </>
+  );
+};
+
+const createDelay = ({
+  offset,
+  index,
+  delay,
+}: Pick<ReducedValue, "offset" | "delay"> & {
+  index: number;
+}) => {
+  return delay + (index + offset) * 50 + "ms";
+};
+
+const createAnimatedNodes = (
+  args: ReducedValue,
+  word: string,
+  index: number,
+): ReducedValue => {
+  const { nodes, offset, wordsLength, textLength, mode, direction, duration, delay, blur } = args;
+
+  const isWordMode = mode === "word";
+  const isUp = direction === "up";
+  const length = isWordMode ? wordsLength : textLength;
+  const isLast = index === length - 1;
+
+  const className = cn(
+    "inline-block opacity-0 transition-all ease-in-out fill-mode-forwards",
+    {
+      // Determine the animation direction
+      ["animate-[reveal-down]"]: !isUp && !blur,
+      ["animate-[reveal-up]"]: isUp && !blur,
+      ["animate-[reveal-down,content-blur]"]: !isUp && blur,
+      ["animate-[reveal-up,content-blur]"]: isUp && blur,
+    },
+    args.className,
+  );
+  const node = (
+    <span
+      key={`word_${index}`}
+      className={cn("contents", {
+        [className]: isWordMode,
+      })}
+      style={
+        isWordMode
+          ? {
+              animationDuration: `${duration}`,
+              animationDelay: createDelay({
+                index,
+                offset,
+                delay,
+              }),
+            }
+          : undefined
+      }
+    >
+      <Word
+        isWordMode={isWordMode}
+        word={word}
+        index={index}
+        offset={offset}
+        duration={duration}
+        className={className}
+        length={length}
+        delay={delay}
+      />
+      {!isLast && " "}
+    </span>
+  );
+
+  return {
+    ...args,
+    nodes: [...nodes, node],
+    offset: offset + (isWordMode ? 1 : word.length + 1),
+  };
+};
+
+export default function WaveReveal({
+  text,
+  direction = "down",
+  mode = "letter",
+  className,
+  duration = "2000ms",
+  delay = 0,
+  blur = true,
+  letterClassName,
+}: WaveRevealProps) {
+  if (!text) {
+    return null;
+  }
+
+  const words = text.trim().split(/\s/);
+
+  const { nodes } = words.reduce<ReducedValue>(createAnimatedNodes, {
+    nodes: [],
+    offset: 0,
+    wordsLength: words.length,
+    textLength: text.length,
+    direction,
+    mode,
+    duration: duration ?? 60,
+    delay: delay ?? 0,
+    blur,
+    className: letterClassName,
+  });
+
+  return (
+    <div
+      className={cn(
+        "relative flex flex-wrap justify-center whitespace-pre px-2 text-4xl font-black md:px-6 md:text-7xl",
+        className,
+      )}
+    >
+      {nodes}
+      <div className="sr-only">{text}</div>
+    </div>
+  );
+}
+

--- a/dashboard/tailwind.config.ts
+++ b/dashboard/tailwind.config.ts
@@ -11,6 +11,9 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      transitionTimingFunction: {
+        "minor-spring": "cubic-bezier(0.18,0.89,0.82,1.04)",
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic":
@@ -137,6 +140,18 @@ const config: Config = {
         "marquee-y": {
           from: { transform: "translateY(0)" },
           to: { transform: "translateY(calc(-100% - var(--gap)))" },
+        },
+        "reveal-up": {
+          "0%": { opacity: "0", transform: "translateY(80%)" },
+          "100%": { opacity: "1", transform: "translateY(0)" },
+        },
+        "reveal-down": {
+          "0%": { opacity: "0", transform: "translateY(-80%)" },
+          "100%": { opacity: "1", transform: "translateY(0)" },
+        },
+        "content-blur": {
+          "0%": { filter: "blur(0.3rem)" },
+          "100%": { filter: "blur(0)" },
         },
       },
       animation: {


### PR DESCRIPTION
## Summary
- add WaveReveal component for animated text reveal
- extend Tailwind config with custom timing and keyframes
- animate policyholder dashboard welcome message using WaveReveal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error: The keyword 'import' is reserved)*
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689f2ab1bc3083209cec7b3bfc8245a8